### PR TITLE
Include fork in published name, register elixirLS as langId, add language server tracing setting UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elixir-ls",
-  "version": "0.2.24",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Jake Becker",
   "license": "MIT",
   "publisher": "elixir-lsp",
-  "version": "0.2.24",
+  "version": "0.3.0",
   "engines": {
     "vscode": "^1.25.1"
   },
@@ -102,6 +102,16 @@
           "type": "boolean",
           "description": "Suggest @spec annotations inline using Dialyzer's inferred success typings (Requires Dialyzer)",
           "default": true
+        },
+        "elixirLS.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the Elixir language server."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       }
     },
     "configuration": {
-      "title": "ElixirLS configuration",
+      "title": "ElixirLS",
       "properties": {
         "elixirLS.dialyzerEnabled": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elixir-ls",
-  "displayName": "ElixirLS: Elixir support and debugger",
+  "displayName": "ElixirLS Fork: Elixir support and debugger",
   "homepage": "https://github.com/elixir-lsp/elixir-ls",
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,8 +55,8 @@ export function activate(context: ExtensionContext) {
 
   // Create the language client and start the client.
   let disposable = new LanguageClient(
-    "ElixirLS",
-    "ElixirLS",
+    "elixirLS", // langId
+    "ElixirLS Fork", // display name
     serverOptions,
     clientOptions
   ).start();
@@ -90,7 +90,7 @@ function testElixir() {
     );
     console.warn(
       `Failed to run 'elixir' command. Current process's PATH: ${
-        process.env["PATH"]
+      process.env["PATH"]
       }`
     );
     return false;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ export function activate(context: ExtensionContext) {
   // Create the language client and start the client.
   let disposable = new LanguageClient(
     "elixirLS", // langId
-    "ElixirLS Fork", // display name
+    "ElixirLS", // display name
     serverOptions,
     clientOptions
   ).start();


### PR DESCRIPTION
- Change display name to ElixirLS Fork to not mislead anyone in what they are installing.
- Register the langId we've already been using in config.  Doing so allows us to set elixirLS.trace.server to turn on language server tracing, instead of having to use ElixirLS.trace.server, which is inconsistent with our existing settings.
- Add UI for setting `elixirLS.server.trace`
- Change `ElixirLS configuration` to `ElixirLS` for consistency with other extensions UI elements
- Bump version in prep for initial published version