### PR TITLE
Add some basic configuration for HTML (EEx) files

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
         "editor.trimAutoWhitespace": false,
         "files.trimTrailingWhitespace": true,
         "files.insertFinalNewline": true
+      },
+      "[HTML (EEx)]": {
+        "editor.trimAutoWhitespace": false,
+        "files.trimTrailingWhitespace": true,
+        "files.insertFinalNewline": true
       }
     },
     "configuration": {


### PR DESCRIPTION
Hey there! :wave: I love this plugin, and wanted to add a little more configuration that I hope will be appreciated. :smile:

I noticed that there was no included configuration for the "HTML (EEx)" file type, and this resulted in some files in the projects that I work on ending up with trailing whitespace, missing final newlines, that sort of thing. I added some rather conservative configuration for the HTML (EEx) type that I believe most folks can agree on.