### PR TITLE
Add function definiton scope

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -107,6 +107,7 @@
     },
     {
       "comment": "Function with parameters",
+      "name": "meta.definition.function.elixir",
       "begin": "\\b(defp?|defmacrop?)\\b\\s*([_$a-z][$\\w]*[!?]?)\\s*\\(",
       "beginCaptures": {
         "1": {
@@ -128,6 +129,7 @@
     },
     {
       "comment": "Function without parameters",
+      "name": "meta.definition.function.elixir",
       "match": "\\b(defp?|defmacrop?)\\b\\s*([_$a-z][$\\w]*[!?]?)",
       "captures": {
         "1": {


### PR DESCRIPTION
## Objective

Add a scope for function definition which combined with the other token can be used to differentiate definition from calls.

![Function definition with different style from a function call](https://user-images.githubusercontent.com/17054180/72560013-e2cac700-3884-11ea-86cf-c6013186f96c.gif)

## Details

Add to the function definition rule the `meta.definition.function.elixir` scope for function with and without parameters.

<img width="639" alt="Function call with only entity.name.function scope" src="https://user-images.githubusercontent.com/17054180/72560760-7bae1200-3886-11ea-98dd-26ad9804f503.png">
<img width="927" alt="Function definition with entity.name.function and meta.definition.function" src="https://user-images.githubusercontent.com/17054180/72560761-7bae1200-3886-11ea-84af-9bd71407772a.png">

The theme is defined as below

```json
{
  "name": "Function name",
  "scope": "entity.name.function",
  "settings": {
    "fontStyle": "",
    "foreground": "#ff6333"
  }
},
{
  "name": "Function definition name",
  "scope": [
    "meta.definition.function entity.name.function"
  ],
  "settings": {
    "fontStyle": "italic",
    "foreground": "#ffd400"
  }
}
```

cc @axelson @thiagomajesk