### PR TITLE
Differentiate syntax between entity.name.function and meta.function-call

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -162,7 +162,7 @@
           "name": "punctuation.separator.method.elixir"
         },
         "3": {
-          "name": "entity.name.function.elixir"
+          "name": "meta.function-call"
         }
       }
     },
@@ -177,7 +177,7 @@
           "name": "punctuation.separator.method.elixir"
         },
         "3": {
-          "name": "entity.name.function.elixir"
+          "name": "meta.function-call"
         }
       }
     },
@@ -189,13 +189,13 @@
           "name": "keyword.operator.other.elixir"
         },
         "2": {
-          "name": "entity.name.function.elixir"
+          "name": "meta.function-call"
         }
       }
     },
     {
       "match": "\\b[a-z_]\\w*[!?]?(?=\\s*?\\.?\\s*?\\()",
-      "name": "entity.name.function.elixir"
+      "name": "meta.function-call"
     },
     {
       "match": "\\b[A-Z]\\w*\\b",


### PR DESCRIPTION
Thanks for this great project! When I jumped over to the fork, it looks like cc07ee2 introduced a syntax highlight regression where function definition were highlighted the same as function calls, which removes the ability to customize the differences in a color theme. I changed the call patterns to use `meta.function-call` instead, which appears to work perfectly. This is my first foray into TM theme rules so I may be missing some caveats here, but happy to help move this along. Thanks!