### PR TITLE
Differentiate syntax between function definitions and function calls

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -108,6 +108,7 @@
     {
       "comment": "Function with parameters",
       "begin": "\\b(defp?|defmacrop?)\\b\\s*([_$a-z][$\\w]*[!?]?)\\s*\\(",
+      "name": "meta.function.definition.elixir",
       "beginCaptures": {
         "1": {
           "name": "keyword.control.elixir"
@@ -129,6 +130,7 @@
     {
       "comment": "Function without parameters",
       "match": "\\b(defp?|defmacrop?)\\b\\s*([_$a-z][$\\w]*[!?]?)",
+      "name": "meta.function.definition.elixir",
       "captures": {
         "1": {
           "name": "keyword.control.elixir"
@@ -162,7 +164,7 @@
           "name": "punctuation.separator.method.elixir"
         },
         "3": {
-          "name": "entity.name.function.elixir"
+          "name": "entity.name.function-call.elixir"
         }
       }
     },
@@ -177,7 +179,7 @@
           "name": "punctuation.separator.method.elixir"
         },
         "3": {
-          "name": "entity.name.function.elixir"
+          "name": "entity.name.function-call.elixir"
         }
       }
     },
@@ -189,13 +191,13 @@
           "name": "keyword.operator.other.elixir"
         },
         "2": {
-          "name": "entity.name.function.elixir"
+          "name": "entity.name.function-call.elixir"
         }
       }
     },
     {
       "match": "\\b[a-z_]\\w*[!?]?(?=\\s*?\\.?\\s*?\\()",
-      "name": "entity.name.function.elixir"
+      "name": "entity.name.function-call.elixir"
     },
     {
       "match": "\\b[A-Z]\\w*\\b",


### PR DESCRIPTION
Goals:
* By default in most themes, function calls should not be highlighted the same
  as function calls
  * Most syntaxes only define function definitions, so most themes highlight
    those definitions with a rather bold color, applying the same coloring to
    all functions calls results in visual noise
* It should still be possible to define custom highlighting for function calls

State of syntax highlighting:
* Textmate syntax highlighting standard (as defined by [1]) defines function
definitions (`entity.name.function`) but says nothing about function calls
* Most themes do not support special coloring for function calls
* We can't expect most themes to add special Elixir support

This PR combines portions of #30 and #38 that have similar goals.

PR #30 by itself did not fully accomplish my goals because function calls are
still annotated with `entity.name.function.elixir` which is highlighted as a
function definition

PR #38 changed the function call names, but it changed it to a non-standard scope.

So in this PR we change the `entity.name.function.elixir` to
`entity.name.function-call.elixir` which allows customization, but is a scope
that that does not have default coloring in most themes (while still being
semantically similar).

Also Ruby's syntax uses the similar `entity.name.function-call.ruby`:
https://github.com/rubyide/vscode-ruby/blob/b232cfd0c96f41ceab72655dcfa17dab40c05562/packages/vscode-ruby/syntaxes/ruby.cson.json#L2243

Related comment: https://github.com/elixir-editors/elixir-tmbundle/pull/179#issuecomment-529169074

cc: @thiagomajesk, @CaiqueMitsuoka, @chrismccord

[1] https://macromates.com/manual/en/language_grammars