### PR TITLE
Update conflicting extensions list

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ export let languageClient: LanguageClient;
 export function activate(context: ExtensionContext): void {
   testElixir();
   detectConflictingExtension("mjmcloug.vscode-elixir");
-  detectConflictingExtension("jakebecker.elixir-ls");
+  detectConflictingExtension("elixir-lsp.elixir-ls");
 
   vscode.commands.registerCommand('extension.copyDebugInfo', copyDebugInfo);
 


### PR DESCRIPTION
In #61 we changed the publisher back to `JakeBecker`, so now we need to update the conflicting extensions list to match that change

Fixes #63