### PR TITLE
Run a language server for each workspace

### DIFF
--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -3,7 +3,7 @@ import * as assert from "assert";
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from "vscode";
-import { languageClient } from "../../extension";
+import { defaultClient } from "../../extension";
 
 let extension: vscode.Extension<void>;
 
@@ -17,6 +17,6 @@ suite("Extension Test Suite", () => {
 
   test("extention is available", async () => {
     assert.ok(extension.isActive);
-    assert.ok(languageClient);
+    assert.ok(defaultClient);
   });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -17,6 +17,9 @@ suite("Extension Test Suite", () => {
 
   test("extention is available", async () => {
     assert.ok(extension.isActive);
+    const sampleFileUri = vscode.Uri.parse('untitled:sample.ex');
+    const document = await vscode.workspace.openTextDocument(sampleFileUri);
+    await vscode.window.showTextDocument(document);
     assert.ok(defaultClient);
   });
 });


### PR DESCRIPTION
This fixes https://github.com/elixir-lsp/vscode-elixir-ls/issues/69 and possibly https://github.com/elixir-lsp/vscode-elixir-ls/issues/58

It spawns a "default" language server for open files not belonging to a workspace and a language server for each workspace.
This way each language server uses the correct workspace root folder instead of the first open workspace.

Solution found in https://github.com/microsoft/vscode/wiki/Adopting-Multi-Root-Workspace-APIs and https://github.com/microsoft/vscode-extension-samples/tree/master/lsp-multi-server-sample

The other way would be to handle the different workspaces on the language server but that is probably more complicated and this might be a viable solution in the meantime.

If you are ok with this solution I'll do more manual testing and see if I can cleanup the code a little more