### PR TITLE
migrate tasks to 2.0.0 syntax

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,18 +8,23 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-  "version": "0.1.0",
-  "command": "npm",
-  "isShellCommand": true,
-  "suppressTaskName": true,
+  "version": "2.0.0",
   "tasks": [
     {
-      "taskName": "build",
+      "label": "build",
+      "type": "shell",
+      "command": "npm",
       "args": ["run", "compile"],
-      "echoCommand": true,
-      "isBuildCommand": true,
-      "showOutput": "always",
-      "problemMatcher": "$tsc-watch"
+      "group": "build",
+      "problemMatcher": "$tsc-watch",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": false
+      }
     }
   ]
 }


### PR DESCRIPTION
Attempting to launch the Extension Development Host window with `F5` threw an error for me, because `tasks.json` was still using `0.1.0` syntax. Updating to `2.0.0` syntax fixed the problem for me. It's possible that locally installing the packaged extension (as described in the README) circumvents this problem, or that other contributors have been focused on ElixirLS, and don't actually develop in VS Code. In any event, I see no harm in using the new syntax :smile:.