### PR TITLE
add `%` as a dedicated punctuation scope

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -2347,6 +2347,10 @@
       "name": "punctuation.separator.method.elixir"
     },
     {
+      "match": "%",
+      "name": "punctuation.definition.map.elixir"
+    },
+    {
       "match": "\\{|\\}",
       "name": "punctuation.section.scope.elixir"
     },


### PR DESCRIPTION
The way this Elixir syntax is written doesn't specifically address capture groups for maps or structs. As a result, somehow `%` was left out of all scopes, including punctuation. I considered writing a proper struct/map regex to capture all the scopes (and I am still happy to do that), but this was the simplest solution to allow `%` to match other punctuation (or be themed in general). Since Elixir doesn't use `%` as a modulo operator, it seems safe to simply give it the one scope in all contexts. Giving it a separate scope allows theme designers to contrast it with the neighboring curly braces if they prefer.

Struct names are currently scoped as `variable.other.constant.elixir`. That scope was intended for references to module names, but it ends up capturing any capitalized name, including structs. That doesn't bother me, but if others prefer to theme struct names independently, I can add the full regex with captures.