### PR TITLE
Add Elixir syntax highlighting in Markdown code block

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,16 @@
         "language": "HTML (EEx)",
         "scopeName": "text.html.elixir",
         "path": "./syntaxes/html (eex).json"
+      },
+      {
+        "scopeName": "markdown.elixir.codeblock",
+        "path": "./syntaxes/codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.elixir": "source.elixir"
+        }
       }
     ],
     "breakpoints": [

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,0 +1,45 @@
+{
+  "comment": "Elixir syntax highlighting in Markdown code block",
+  "scopeName": "markdown.elixir.codeblock",
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#fenced_code_block_elixir"
+    }
+  ],
+  "repository": {
+    "fenced_code_block_elixir": {
+      "begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(elixir)(\\s+[^`~]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "5": {
+          "name": "fenced_code.block.language"
+        },
+        "6": {
+          "name": "fenced_code.block.language.attributes"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.elixir",
+          "patterns": [
+            {
+              "include": "source.elixir"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I have tested the package locally and it is working fine. Here is the result:

<img width="407" alt="Screen Shot 2020-04-17 at 17 01 04" src="https://user-images.githubusercontent.com/1788571/79577570-95e9cd00-80cd-11ea-9c10-569c75b87746.png">
