### PR TITLE
Trim final newlines

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,14 @@
         "editor.formatOnType": true,
         "editor.trimAutoWhitespace": false,
         "files.trimTrailingWhitespace": true,
-        "files.insertFinalNewline": true
+        "files.insertFinalNewline": true,
+        "files.trimFinalNewlines": true
       },
       "[HTML (EEx)]": {
         "editor.trimAutoWhitespace": false,
         "files.trimTrailingWhitespace": true,
-        "files.insertFinalNewline": true
+        "files.insertFinalNewline": true,
+        "files.trimFinalNewlines": true
       }
     },
     "configuration": {


### PR DESCRIPTION
Remove all trailing newlines after the final newline in the file.

This actually does not contradict `"files.insertFinalNewline"` as I feared it would, as the documenation reads
> When enabled, will trim all new lines _after the final new line_ at the end of the file when saving it.

(emphasis mine)