### PR TITLE
remove unnecessary captures within pipe expressions (fixes #78):

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -184,18 +184,6 @@
       }
     },
     {
-      "comment": "Pipe operator call without parenthesis",
-      "match": "(\\|\\>)\\s*([a-z_]\\w*[!?]?)",
-      "captures": {
-        "1": {
-          "name": "keyword.operator.other.elixir"
-        },
-        "2": {
-          "name": "entity.name.function-call.elixir"
-        }
-      }
-    },
-    {
       "match": "\\b[a-z_]\\w*[!?]?(?=\\s*?\\.?\\s*?\\()",
       "name": "entity.name.function-call.elixir"
     },


### PR DESCRIPTION
#78 is correct - keywords following pipes are not being scoped appropriately. They are being caught up in the 2nd capture group of "Pipe operator call without parenthesis." What's interesting is that the entire block seems redundant:

- The `|>` operator is captured separately elsewhere in the grammar (as `keyword.operator.other.elixir`), so removing the first capture does not affect scoping/highlighting of the pipe itself.
- If the first entity after the pipe is in fact a function call, then it will also be scoped appropriately (as `entity.name.function-call.elixir`) without any special capturing, so the 2nd capture group can be removed as well.
- If the first entity after the pipe is not a function call, then removing this block allows it to be captured by the appropriate pattern (such as `keyword.control.elixir`). Since this can be done without any explicit `include`s, this seems like all upside to me. We aren't deleting any parent scope for the entire expression, because only the sub-captures were used.