### PR TITLE
add filetype and watcher for liveview html.leex templates 

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,7 +95,7 @@ export function activate(context: ExtensionContext): void {
       configurationSection: "elixirLS",
       // Notify the server about file changes to Elixir files contained in the workspace
       fileEvents: [
-        workspace.createFileSystemWatcher("**/*.{ex,exs,erl,yrl,xrl,eex}")
+        workspace.createFileSystemWatcher("**/*.{ex,exs,erl,yrl,xrl,eex,leex}")
       ]
     }
   };

--- a/syntaxes/html (eex).json
+++ b/syntaxes/html (eex).json
@@ -1,5 +1,5 @@
 {
-  "fileTypes": ["html.eex"],
+  "fileTypes": ["html.eex", "html.leex"],
   "foldingStartMarker": "(?x)\n\t\t(<(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|form|dl)\\b.*?>\n\t\t|<!--(?!.*-->)\n\t\t|\\{\\s*($|\\?>\\s*$|//|/\\*(.*\\*/\\s*$|(?!.*?\\*/)))\n\t\t)",
   "foldingStopMarker": "(?x)\n\t\t(</(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|form|dl)>\n\t\t|^\\s*-->\n\t\t|(^|\\s)\\}\n\t\t)",
   "injections": {


### PR DESCRIPTION
With the release of Phoenix 1.5 it's much easier to include [LiveView](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html) 

https://www.phoenixframework.org/blog/build-a-real-time-twitter-clone-in-15-minutes-with-live-view-and-phoenix-1-5 

This PR adds the .html.leex filetype for syntax highlighting 