### PR TITLE
Change Language IDs to comply with guidelines (Closes #86)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "files.trimTrailingWhitespace": true,
         "files.insertFinalNewline": true
       },
-      "[HTML (EEx)]": {
+      "[html-eex]": {
         "editor.trimAutoWhitespace": false,
         "files.trimTrailingWhitespace": true,
         "files.insertFinalNewline": true
@@ -136,8 +136,9 @@
         "configuration": "./elixir-language-configuration.json"
       },
       {
-        "id": "EEx",
+        "id": "eex",
         "aliases": [
+          "Embedded Elixir",
           "EEx",
           "eex"
         ],
@@ -147,8 +148,9 @@
         "configuration": "./eex-language-configuration.json"
       },
       {
-        "id": "HTML (EEx)",
+        "id": "html-eex",
         "aliases": [
+          "HTML (Embedded Elixir)",
           "HTML (EEx)"
         ],
         "extensions": [
@@ -165,14 +167,14 @@
         "path": "./syntaxes/elixir.json"
       },
       {
-        "language": "EEx",
+        "language": "eex",
         "scopeName": "text.elixir",
         "path": "./syntaxes/eex.json"
       },
       {
-        "language": "HTML (EEx)",
+        "language": "html-eex",
         "scopeName": "text.html.elixir",
-        "path": "./syntaxes/html (eex).json"
+        "path": "./syntaxes/html-eex.json"
       }
     ],
     "breakpoints": [

--- a/syntaxes/eex.json
+++ b/syntaxes/eex.json
@@ -1,6 +1,6 @@
 {
   "fileTypes": ["eex"],
-  "name": "EEx",
+  "name": "Embedded Elixir",
   "patterns": [
     {
       "begin": "<%+#",

--- a/syntaxes/html-eex.json
+++ b/syntaxes/html-eex.json
@@ -12,7 +12,7 @@
       ]
     }
   },
-  "name": "HTML (EEx)",
+  "name": "HTML (Embedded Elixir)",
   "patterns": [
     {
       "include": "text.elixir"


### PR DESCRIPTION
@axelson Here you are! I'm not sure of the full extent of testing this that should occur or if we should combine its merger with pull requests on other popular packages supporting `html.eex` to reduce the impact of the change.
 
The language identifier guidelines state that language ids should be lowercase and contain no spaces.
https://code.visualstudio.com/docs/languages/identifiers#_new-identifier-guidelines

This mostly is a port of changes that were never merged for the old vscode-elixir definition.
https://github.com/fr1zle/vscode-elixir/pull/114

The largest impact of this change is that other extensions that rely on the current identifier would have to be changed for support to continue.

Fixes #86
