### PR TITLE
Improve phoenix templates support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "Debuggers"
   ],
   "activationEvents": [
-    "onLanguage:elixir"
+    "onLanguage:elixir",
+    "onLanguage:eex",
+    "onLanguage:html-eex"
   ],
   "main": "./out/extension",
   "contributes": {
@@ -143,7 +145,8 @@
           "eex"
         ],
         "extensions": [
-          ".eex"
+          ".eex",
+          ".leex"
         ],
         "configuration": "./eex-language-configuration.json"
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,11 @@ export function activate(context: ExtensionContext): void {
     // Register the server for Elixir documents
     documentSelector: [
       { language: "elixir", scheme: "file" },
-      { language: "elixir", scheme: "untitled" }
+      { language: "elixir", scheme: "untitled" },
+      { language: "eex", scheme: "file" },
+      { language: "eex", scheme: "untitled" },
+      { language: "html-eex", scheme: "file" },
+      { language: "html-eex", scheme: "untitled" }
     ],
     // Don't focus the Output pane on errors because request handler errors are no big deal
     revealOutputChannelOn: RevealOutputChannelOn.Never,

--- a/syntaxes/eex.json
+++ b/syntaxes/eex.json
@@ -1,5 +1,5 @@
 {
-  "fileTypes": ["eex"],
+  "fileTypes": ["eex", "leex"],
   "name": "Embedded Elixir",
   "patterns": [
     {


### PR DESCRIPTION
Improvements:

1. Activate server on `.eex` and `.leex` files. Otherwise, errors on the templates will only be reported when opening a `.ex` file.

2. Register `.eex` and `.leex` files as Elixir documents so errors/warnings in those files they can be properly handled.

Along with https://github.com/elixir-lsp/elixir-ls/pull/241, this PR provides a much better development experience when working with phoenix templates.