### PR TITLE
add keyword scopes for tests

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -102,7 +102,7 @@
       "name": "constant.other.symbol.elixir"
     },
     {
-      "match": "(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|defguardp?|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when|and|or|not|in)\\b(?![?!])",
+      "match": "(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|defguardp?|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when|and|or|not|in|test|assert|assert_raise)\\b(?![?!])",
       "name": "keyword.control.elixir"
     },
     {

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -102,7 +102,7 @@
       "name": "constant.other.symbol.elixir"
     },
     {
-      "match": "(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|defguardp?|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when|and|or|not|in|test|assert|assert_raise)\\b(?![?!])",
+      "match": "(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|defguardp?|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when|and|or|not|in|assert|assert_raise)\\b(?![?!])",
       "name": "keyword.control.elixir"
     },
     {


### PR DESCRIPTION
Currently keywords that are specific to tests receive no scope/highlight. This PR adds `test`, `assert`, and `assert_raise` to `keyword.control.elixir`. I can break testing keywords out into a separate scope if you prefer, but this seemed the simplest solution.