### PR TITLE
Fix type errors

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,17 +126,21 @@ function getOuterMostWorkspaceFolder(folder: WorkspaceFolder): WorkspaceFolder {
 }
 
 class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescriptorFactory {
-  createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
-    const cwd: String = session.workspaceFolder.uri.toString().replace("file://", "");
+  createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+    if (session.workspaceFolder) {
+      const cwd: string = session.workspaceFolder.uri.toString().replace("file://", "");
 
-    let options;
-    if (executable.options) {
-      options = { ...executable.options, cwd };
-    } else {
-      options = { cwd };
+      let options;
+      if (executable.options) {
+        options = { ...executable.options, cwd };
+      } else {
+        options = { cwd };
+      }
+
+      return new vscode.DebugAdapterExecutable(executable.command, executable.args, options);
     }
 
-    return new vscode.DebugAdapterExecutable(executable.command, executable.args, options);
+    return executable;
   }
 }
 


### PR DESCRIPTION
Not sure how I managed to compile successfully earlier.

<details>
<summary>Errors</summary>

```
src/extension.ts:130:25 - error TS2532: Object is possibly 'undefined'.

130     const cwd: string = session.workspaceFolder.uri.toString().replace("file://", "");
                            ~~~~~~~~~~~~~~~~~~~~~~~

src/extension.ts:133:9 - error TS2532: Object is possibly 'undefined'.

133     if (executable.options) {
            ~~~~~~~~~~

src/extension.ts:134:22 - error TS2532: Object is possibly 'undefined'.

134       options = { ...executable.options, cwd };
                         ~~~~~~~~~~

src/extension.ts:139:46 - error TS2532: Object is possibly 'undefined'.

139     return new vscode.DebugAdapterExecutable(executable.command, executable.args, options);
                                                 ~~~~~~~~~~

src/extension.ts:139:66 - error TS2532: Object is possibly 'undefined'.

139     return new vscode.DebugAdapterExecutable(executable.command, executable.args, options);
                                                                     ~~~~~~~~~~


Found 5 errors.
```
</details>