### PR TITLE
Add Dialyzer formatter descriptions and default to long

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,12 @@
             "dialyxir_short",
             "dialyxir_long"
           ],
-          "default": "dialyzer"
+          "markdownEnumDescriptions": [
+            "Original Dialyzer format",
+            "Same as `mix dialyzer --format short`",
+            "Same as `mix dialyzer --format long`"
+          ],
+          "default": "dialyxir_long"
         },
         "elixirLS.mixEnv": {
           "type": "string",


### PR DESCRIPTION
#67 says ”short” but https://github.com/elixir-lsp/elixir-ls/issues/31 defaults to long now. So `dialyxir_long` is chosen.