### PR TITLE
Activate extension when workspace contains elixir files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "Debuggers"
   ],
   "activationEvents": [
+    "workspaceContains:**/*.ex",
+    "workspaceContains:**/*.exs",
     "onLanguage:elixir",
     "onLanguage:eex",
     "onLanguage:html-eex"


### PR DESCRIPTION
A specific benefit of this is the ability to run the "Elixir LS: Copy Debug Info" command on a multi-root workspace before opening an elixir file.

As discussed in #70 