### PR TITLE
Revert "Activate extension when workspace contains elixir files"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "Debuggers"
   ],
   "activationEvents": [
-    "workspaceContains:**/*.ex",
-    "workspaceContains:**/*.exs",
     "onLanguage:elixir",
     "onLanguage:eex",
     "onLanguage:html-eex"


### PR DESCRIPTION
Reverts elixir-lsp/vscode-elixir-ls#107

Please see Issue #114 

On Windows, this PR causes a timeout which prevents the debugger from launching.