### PR TITLE
Only enable Copy Debug Info when editing Elixir files

### DIFF
--- a/package.json
+++ b/package.json
@@ -385,7 +385,15 @@
         "command": "extension.copyDebugInfo",
         "title": "ElixirLS: Copy Debug Info"
       }
-    ]
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "extension.copyDebugInfo",
+          "when": "editorLangId == elixir || editorLangId == eex || editorLangId == html-eex"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "./prepublish.bash",


### PR DESCRIPTION
As suggested in https://github.com/elixir-lsp/vscode-elixir-ls/issues/114#issuecomment-653714354.

This resolves https://github.com/elixir-lsp/vscode-elixir-ls/pull/70#issuecomment-640395218 with the trade off that the _Copy Debug Info_ command is only available after Elixir files are opened.