### PR TITLE
Increment package to dev version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "The Elixir community",
   "license": "MIT",
   "publisher": "JakeBecker",
-  "version": "0.5.0",
+  "version": "0.6.0-dev",
   "engines": {
     "vscode": "^1.44.0"
   },


### PR DESCRIPTION
This makes it easier to tell when you are running a dev version of the extension vs. the version on the marketplace.