### PR TITLE
Add task to run test at cursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -393,7 +393,12 @@
           "when": "editorLangId == elixir || editorLangId == eex || editorLangId == html-eex"
         }
       ]
-    }
+    },
+    "taskDefinitions": [
+      {
+        "type": "ElixirLS"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "./prepublish.bash",

--- a/src/TaskProvider.ts
+++ b/src/TaskProvider.ts
@@ -1,0 +1,32 @@
+import * as vscode from 'vscode';
+
+export class TaskProvider implements vscode.TaskProvider {
+    // Referenced in package.json::taskDefinitions
+    static TaskType = 'ElixirLS';
+
+    public provideTasks(): vscode.Task[] {
+        const wsFolders = vscode.workspace.workspaceFolders;
+        if (!wsFolders || !wsFolders[0]) {
+            vscode.window.showErrorMessage("no workspace open...");
+            return [];
+        }
+
+        const kind: vscode.TaskDefinition = { type: TaskProvider.TaskType }
+        const task = new vscode.Task(
+            kind,
+            wsFolders[0],
+            'Run test at cursor',
+            TaskProvider.TaskType,
+            new vscode.ShellExecution("mix test ${relativeFile}:${lineNumber}")
+        );
+
+        task.group = vscode.TaskGroup.Test;
+        return [task];
+    }
+
+    public resolveTask(_task: vscode.Task): vscode.Task | undefined {
+        // This method can be implemented to improve performance.
+        // See: https://code.visualstudio.com/api/extension-guides/task-provider
+        return undefined;
+    }
+}

--- a/src/TaskProvider.ts
+++ b/src/TaskProvider.ts
@@ -12,16 +12,30 @@ export class TaskProvider implements vscode.TaskProvider {
         }
 
         const kind: vscode.TaskDefinition = { type: TaskProvider.TaskType }
-        const task = new vscode.Task(
+
+        const testUnderCursorTask = new vscode.Task(
             kind,
             wsFolders[0],
             'Run test at cursor',
             TaskProvider.TaskType,
-            new vscode.ShellExecution("mix test ${relativeFile}:${lineNumber}")
+            new vscode.ShellExecution("mix test ${relativeFile}:${lineNumber}"),
+            ["$mixCompileError", "$mixCompileWarning", "$mixTestFailure"]
         );
 
-        task.group = vscode.TaskGroup.Test;
-        return [task];
+        testUnderCursorTask.group = vscode.TaskGroup.Test;
+
+        const testsInFileTask = new vscode.Task(
+            kind,
+            wsFolders[0],
+            'Run tests in current file',
+            TaskProvider.TaskType,
+            new vscode.ShellExecution("mix test ${relativeFile}"),
+            ["$mixCompileError", "$mixCompileWarning", "$mixTestFailure"]
+        );
+
+        testsInFileTask.group = vscode.TaskGroup.Test;
+
+        return [testUnderCursorTask, testsInFileTask];
     }
 
     public resolveTask(_task: vscode.Task): vscode.Task | undefined {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import {
   ServerOptions,
 } from "vscode-languageclient";
 import * as os from "os";
+import { TaskProvider } from "./TaskProvider";
 
 export let defaultClient: LanguageClient;
 const clients: Map<string, LanguageClient> = new Map();
@@ -65,9 +66,9 @@ function detectConflictingExtension(extensionId: string): void {
   if (extension) {
     vscode.window.showErrorMessage(
       "Warning: " +
-        extensionId +
-        " is not compatible with ElixirLS, please uninstall " +
-        extensionId
+      extensionId +
+      " is not compatible with ElixirLS, please uninstall " +
+      extensionId
     );
   }
 }
@@ -93,16 +94,16 @@ function sortedWorkspaceFolders(): string[] {
   if (_sortedWorkspaceFolders === void 0) {
     _sortedWorkspaceFolders = workspace.workspaceFolders
       ? workspace.workspaceFolders
-          .map((folder) => {
-            let result = folder.uri.toString();
-            if (result.charAt(result.length - 1) !== "/") {
-              result = result + "/";
-            }
-            return result;
-          })
-          .sort((a, b) => {
-            return a.length - b.length;
-          })
+        .map((folder) => {
+          let result = folder.uri.toString();
+          if (result.charAt(result.length - 1) !== "/") {
+            result = result + "/";
+          }
+          return result;
+        })
+        .sort((a, b) => {
+          return a.length - b.length;
+        })
       : [];
   }
   return _sortedWorkspaceFolders;
@@ -278,6 +279,8 @@ export function activate(context: ExtensionContext): void {
       }
     }
   });
+
+  vscode.tasks.registerTaskProvider(TaskProvider.TaskType, new TaskProvider());
 }
 
 export function deactivate(): Thenable<void> {


### PR DESCRIPTION
Adds a task to the extension to run the current test under the cursor.

I wasn't too confident on adding a default keybinding because I'm not familiar with any policies around keybindings in ElixirLS project. If you think it's worth, it can be done too. I currently have it set up to `ctrl + '`.

Below is a screenshot of the task selector + execution.

![image](https://user-images.githubusercontent.com/10437518/86916280-4985ba80-c11b-11ea-9d2f-b7307f0d88d4.png)
