### PR TITLE
Add support for octal number

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -192,7 +192,7 @@
       "name": "variable.other.constant.elixir"
     },
     {
-      "match": "\\b(0[xX]\\h(?>_?\\h)*|\\d(?>_?\\d)*(\\.(?![^[:space:][:digit:]])(?>_?\\d)*)?([eE][-+]?\\d(?>_?\\d)*)?|0[bB][01]+)\\b",
+      "match": "\\b(0[xX]\\h(?>_?\\h)*|\\d(?>_?\\d)*(\\.(?![^[:space:][:digit:]])(?>_?\\d)*)?([eE][-+]?\\d(?>_?\\d)*)?|0[bB][01]+|0o[0-7][_0-7]*[0-7]+)\\b",
       "name": "constant.numeric.elixir"
     },
     {


### PR DESCRIPTION
Add support for octal number

* Mark octal number as a scope constant.numeric.elixir.
* Support underscore separated. For example: 0o012_777.
* Not highlight for octal number that cause syntax error. For example:
  0o77_, which's syntax error cause by ending with underscore.

Test case:

        0o777 # must work
        0o77  # must work
        0o7   # must work
        0o_777 # should not highlight
        # test with variable assignment.
        a_number = 0o777_22_ + 22 # 0o777_22_ should not highlight
        a_number = 0o7777 # must work

Fixes #127