### PR TITLE
Remove check for conflicting extension elixir-lsp.elixir-ls

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -156,7 +156,6 @@ function configureDebugger(context: ExtensionContext) {
 export function activate(context: ExtensionContext): void {
   testElixir();
   detectConflictingExtension("mjmcloug.vscode-elixir");
-  detectConflictingExtension("elixir-lsp.elixir-ls");
   // https://github.com/elixir-lsp/vscode-elixir-ls/issues/34
   detectConflictingExtension("sammkj.vscode-elixir-formatter");
 


### PR DESCRIPTION
This check results in a false-positive warning when used with the openvsx version of the extension because on that registry this extension is published as `elixir-lsp.elixir-ls`. And this was originally needed to detect someone who installed the fork version of vscode-elixir-ls, but most people have migrated already.

Fixes #135