### PR TITLE
Put Symbols in the `constant.language` namespace

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -173,7 +173,7 @@
       "match": "(\\:\\w+)\\s*(\\.)\\s*([_]?\\w*[!?]?)",
       "captures": {
         "1": {
-          "name": "constant.other.symbol.elixir"
+          "name": "constant.language.symbol.elixir"
         },
         "2": {
           "name": "punctuation.separator.method.elixir"
@@ -2104,7 +2104,7 @@
         }
       },
       "end": "'",
-      "name": "constant.other.symbol.single-quoted.elixir",
+      "name": "constant.language.symbol.single-quoted.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -2117,7 +2117,7 @@
     {
       "comment": "symbols with single-quoted string, used as keys in Keyword lists.",
       "match": "(')((?:[^'\\\\]*(?:\\\\.[^'\\\\]*)*))(':)(?!:)",
-      "name": "constant.other.symbol.single-quoted.elixir",
+      "name": "constant.language.symbol.single-quoted.elixir",
       "captures": {
         "1": {
           "name": "punctuation.definition.constant.elixir"
@@ -2145,7 +2145,7 @@
         }
       },
       "end": "\"",
-      "name": "constant.other.symbol.double-quoted.elixir",
+      "name": "constant.language.symbol.double-quoted.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -2230,7 +2230,7 @@
     {
       "comment": "symbols defined by double-quoted string, used as keys in Keyword lists.",
       "match": "(\")((?:[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*))(\":)(?!:)",
-      "name": "constant.other.symbol.double-quoted.elixir",
+      "name": "constant.language.symbol.double-quoted.elixir",
       "captures": {
         "1": {
           "name": "punctuation.definition.constant.elixir"
@@ -2376,7 +2376,7 @@
       },
       "comment": "symbols",
       "match": "(?<!:)(:)(?>[a-zA-Z_][\\w@]*(?>[?!]|=(?![>=]))?|\\<\\>|===?|!==?|<<>>|<<<|>>>|~~~|::|<\\-|\\|>|=>|~|~=|=|/|\\\\\\\\|\\*\\*?|\\.\\.?\\.?|>=?|<=?|&&?&?|\\+\\+?|\\-\\-?|\\|\\|?\\|?|\\!|@|\\%?\\{\\}|%|\\[\\]|\\^(\\^\\^)?)",
-      "name": "constant.other.symbol.elixir"
+      "name": "constant.language.symbol.elixir"
     },
     {
       "match": ":",

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -99,7 +99,7 @@
       },
       "comment": "symbols",
       "match": "(?>[a-zA-Z_][\\w@]*(?>[?!])?)(:)(?!:)",
-      "name": "constant.other.symbol.elixir"
+      "name": "constant.language.symbol.elixir"
     },
     {
       "match": "(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|defguardp?|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when|and|or|not|in)\\b(?![?!])",


### PR DESCRIPTION
This change puts Symbols in `constant.language` Textmate namespace/scope, which gives it special highlighting likening it to the Ruby extension. Before/After with Material Community Theme (Dark High Contranst):

## Before

![image](https://user-images.githubusercontent.com/10534779/93711862-8ea86e80-fb06-11ea-913c-9fbe2649c738.png)

## After

![image](https://user-images.githubusercontent.com/10534779/93711848-6456b100-fb06-11ea-9f74-617e7e010faa.png)
