### PR TITLE
Fix debugger not starting on windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -131,7 +131,7 @@ function configureCopyDebugInfo(context: ExtensionContext) {
 class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescriptorFactory {
   createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
     if (session.workspaceFolder) {
-      const cwd: string = session.workspaceFolder.uri.toString().replace("file://", "");
+      const cwd: string = session.workspaceFolder.uri.fsPath;
 
       let options;
       if (executable.options) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ let _sortedWorkspaceFolders: string[] | undefined;
 
 function testElixirCommand(command: string): false | Buffer {
   try {
-    return execSync(`${command} -e ""`);
+    return execSync(`${command} -e " "`);
   } catch {
     return false;
   }


### PR DESCRIPTION
This PR resolves an issue with invalid cwd passed to `debugger.bat`. It also fixes an unnecessary error during extension start. Refer to specific commits for details.

There are a few more places where URI is transformed by `toString`. Probably more of them need proper handling. I'll check them and update this PR.

Edit:
Other cases of `URI.toString` don't seem to be breaking anything.