### PR TITLE
Fix documents before running tests

### DIFF
--- a/src/commands/runTestFromCodeLens.ts
+++ b/src/commands/runTestFromCodeLens.ts
@@ -9,22 +9,22 @@ type RunArgs = {
 };
 
 export default async function runFromCodeLens(args: RunArgs): Promise<void> {
-  const { activeTextEditor, terminals, createTerminal } = window
+  const { activeTextEditor, terminals, createTerminal } = window;
 
   if (!activeTextEditor) {
-    return
+    return;
   }
 
   if (activeTextEditor.document.isDirty) {
-    const saved = await activeTextEditor.document.save()
+    const saved = await activeTextEditor.document.save();
 
     if (!saved) {
-      return
+      return;
     }
   }
 
   const elixirLsTerminal =
-    terminals.find(terminal => terminal.name == "ElixirLS") ||
+    terminals.find((terminal) => terminal.name == "ElixirLS") ||
     createTerminal("ElixirLS");
 
   elixirLsTerminal.show();

--- a/src/commands/runTestFromCodeLens.ts
+++ b/src/commands/runTestFromCodeLens.ts
@@ -7,13 +7,27 @@ type RunArgs = {
   module?: string
 }
 
-export default function runFromCodeLens(args: RunArgs): void {
+export default async function runFromCodeLens(args: RunArgs): Promise<void> {
+  const { activeTextEditor, terminals } = window
+
+  if (!activeTextEditor) {
+    return
+  }
+
+  if (activeTextEditor.document.isDirty) {
+    const saved = await activeTextEditor.document.save()
+
+    if (!saved) {
+      return
+    }
+  }
+
   const elixirLsTerminal =
-    window.terminals.find(terminal => terminal.name == "ElixirLS") || window.createTerminal("ElixirLS");
+    terminals.find(terminal => terminal.name == "ElixirLS") || window.createTerminal("ElixirLS")
 
   elixirLsTerminal.show()
   elixirLsTerminal.sendText('clear')
-  elixirLsTerminal.sendText(buildTestCommand(args));
+  elixirLsTerminal.sendText(buildTestCommand(args))
 }
 
 function buildTestCommand(args: RunArgs): string {


### PR DESCRIPTION
Updates the run test command to save the current document if necessary, as reported in https://github.com/elixir-lsp/elixir-ls/issues/438.

I haven't found a way to save the document from elixir-ls itself, so it looks like every extension is going to have to re-implement this functionality. Maybe this should be documented somewhere?