### PR TITLE
fix(test lenses): Use single instead of double quotes non-Windows environments and escape nested quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -411,7 +411,8 @@
     "update-vscode": "node ./node_modules/vscode/bin/install",
     "test": "node ./out/test/runTest.js",
     "lint": "eslint . --ext .js,.ts",
-    "check-formatting": "prettier --check ./src/**/*.ts .*.js "
+    "check-formatting": "prettier --check ./src/**/*.ts .*.js ",
+    "fix-formatting": "prettier --write ./src/**/*.ts .*.js "
   },
   "devDependencies": {
     "@types/glob": "^7.1.3",

--- a/src/commands/runTestFromCodeLens.ts
+++ b/src/commands/runTestFromCodeLens.ts
@@ -19,6 +19,19 @@ export default function runFromCodeLens(args: RunArgs): void {
   elixirLsTerminal.sendText(buildTestCommand(args));
 }
 
+function escapeSingleQuotes(s: string): string {
+  return isWindows() ? s : s.replace(/'/g, "'\\''");
+}
+
+function quote(s: string): string {
+  const q = isWindows() ? '"' : `'`;
+  return [q, s, q].join('');
+}
+
+function isWindows(): boolean {
+  return process.platform.includes('win32');
+}
+
 function buildTestCommand(args: RunArgs): string {
   const testFilter = buildTestInclude(
     args.describe,
@@ -26,7 +39,7 @@ function buildTestCommand(args: RunArgs): string {
     args.module
   );
 
-  return `mix test --exclude test --include "${testFilter}" ${args.filePath}`;
+  return `mix test --exclude test --include ${quote(escapeSingleQuotes(testFilter))} ${args.filePath}`;
 }
 
 function buildTestInclude(

--- a/src/commands/runTestFromCodeLens.ts
+++ b/src/commands/runTestFromCodeLens.ts
@@ -25,11 +25,11 @@ function escapeSingleQuotes(s: string): string {
 
 function quote(s: string): string {
   const q = isWindows() ? '"' : `'`;
-  return [q, s, q].join('');
+  return [q, s, q].join("");
 }
 
 function isWindows(): boolean {
-  return process.platform.includes('win32');
+  return process.platform.includes("win32");
 }
 
 function buildTestCommand(args: RunArgs): string {
@@ -39,7 +39,9 @@ function buildTestCommand(args: RunArgs): string {
     args.module
   );
 
-  return `mix test --exclude test --include ${quote(escapeSingleQuotes(testFilter))} ${args.filePath}`;
+  return `mix test --exclude test --include ${quote(
+    escapeSingleQuotes(testFilter)
+  )} ${args.filePath}`;
 }
 
 function buildTestInclude(


### PR DESCRIPTION
Fixes https://github.com/elixir-lsp/elixir-ls/issues/485 and part of https://github.com/elixir-lsp/elixir-ls/issues/438.

Use single quotes in non-windows environments to escape bash special characters. Also escapes nested single quotes.