### PR TITLE
Optional `~S` sigil at start of doc folding region

### DIFF
--- a/elixir-language-configuration.json
+++ b/elixir-language-configuration.json
@@ -62,7 +62,7 @@
   },
   "folding": {
     "markers": {
-      "start": "^\\s*(@(moduledoc|typedoc|doc)\\b\\s+\"\"\")|(#\\s*region\\b)",
+      "start": "^\\s*(@(moduledoc|typedoc|doc)\\b\\s+(~S)?\"\"\")|(#\\s*region\\b)",
       "end": "^\\s+(\"\"\")|(#\\s*endregion\\b)",
     }
   }


### PR DESCRIPTION
`~S"""` is a commonly-used [starting delimiter for doctests](https://elixir-lang.org/getting-started/mix-otp/docs-tests-and-with.html#doctests). From elixir-lang.org's guide on doctests:

> note that we started the documentation string using `@doc ~S"""`. The `~S` prevents the `\r\n` characters from being converted to a carriage return and line feed until they are evaluated in the test.

Adding it as an optional pattern to match on in the folding regex.