### PR TITLE
Change the default of `fetchDeps` to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
           "scope": "resource",
           "type": "boolean",
           "description": "Automatically fetch project dependencies when compiling",
-          "default": true
+          "default": false
         },
         "elixirLS.suggestSpecs": {
           "scope": "resource",


### PR DESCRIPTION
The automatically fetch deps functionality, often trips up developers.
It also has the downside of potentially corrupting the `.elixir_ls`
directory which is difficult to recover from.

However when `fetchDeps` is false the user will need to manually restart
their editor whenever they update their deps. But restarting the editor
is more intuitive than removing `.elixir_ls` and then restarting the
editor.

Hopefully in the future we can detect some situations that requires
ElixirLS to restart and then automatically restart (or present it as a
prompt to the user).