### PR TITLE
editor.tabSize not configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ ElixirLS is opinionated and sets the following default settings for Elixir files
 {
   // Based on Elixir formatter's style
   "editor.insertSpaces": true,
-  "editor.tabSize": 2,
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,


### PR DESCRIPTION
Removed this setting from the readme because having it there gives the impression the tabSize can be overridden, but it can't at the moment