### PR TITLE
Support HEEx and Surface files

### DIFF
--- a/elixir-language-configuration.json
+++ b/elixir-language-configuration.json
@@ -21,6 +21,8 @@
     { "open": "~C\"", "close": "\"" },
     { "open": "~D\"", "close": "\"" },
     { "open": "~E\"", "close": "\"" },
+    { "open": "~F\"", "close": "\"" },
+    { "open": "~H\"", "close": "\"" },
     { "open": "~L\"", "close": "\"" },
     { "open": "~N\"", "close": "\"" },
     { "open": "~R\"", "close": "\"" },
@@ -38,6 +40,8 @@
     { "open": "~C\"\"\"", "close": "\"\"\"" },
     { "open": "~D\"\"\"", "close": "\"\"\"" },
     { "open": "~E\"\"\"", "close": "\"\"\"" },
+    { "open": "~F\"\"\"", "close": "\"\"\"" },
+    { "open": "~H\"\"\"", "close": "\"\"\"" },
     { "open": "~L\"\"\"", "close": "\"\"\"" },
     { "open": "~N\"\"\"", "close": "\"\"\"" },
     { "open": "~R\"\"\"", "close": "\"\"\"" },
@@ -63,7 +67,7 @@
   "folding": {
     "markers": {
       "start": "^\\s*(@(moduledoc|typedoc|doc)\\b\\s+(~S)?\"\"\")|(#\\s*region\\b)",
-      "end": "^\\s+(\"\"\")|(#\\s*endregion\\b)",
+      "end": "^\\s+(\"\"\")|(#\\s*endregion\\b)"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "activationEvents": [
     "onLanguage:elixir",
     "onLanguage:eex",
-    "onLanguage:html-eex"
+    "onLanguage:html-eex",
+    "onLanguage:phoenix-heex",
+    "onLanguage:surface"
   ],
   "main": "./out/extension",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -201,7 +201,7 @@ function configureExpandMacro(context: ExtensionContext) {
     );
     panel.webview.html = getExpandMacroWebviewContent(res);
   });
-  
+
   context.subscriptions.push(disposable);
 }
 
@@ -252,7 +252,7 @@ function configureTerminalLinkProvider(context: ExtensionContext) {
       if (matches === null) {
         return [];
       }
-  
+
       return [
         {
           startIndex: matches.index!,
@@ -276,7 +276,7 @@ function configureTerminalLinkProvider(context: ExtensionContext) {
             if (!selection) {
               return;
             }
-  
+
             openUri(selection.uri, line);
           });
         }
@@ -353,6 +353,10 @@ export function activate(context: ExtensionContext): void {
       { language: "eex", scheme: "untitled" },
       { language: "html-eex", scheme: "file" },
       { language: "html-eex", scheme: "untitled" },
+      { language: "phoenix-heex", scheme: "file" },
+      { language: "phoenix-heex", scheme: "untitled" },
+      { language: "surface", scheme: "file" },
+      { language: "surface", scheme: "untitled" }
     ],
     // Don't focus the Output pane on errors because request handler errors are no big deal
     revealOutputChannelOn: RevealOutputChannelOn.Never,
@@ -361,14 +365,14 @@ export function activate(context: ExtensionContext): void {
       configurationSection: "elixirLS",
       // Notify the server about file changes to Elixir files contained in the workspace
       fileEvents: [
-        workspace.createFileSystemWatcher("**/*.{ex,exs,erl,hrl,yrl,xrl,eex,leex}"),
+        workspace.createFileSystemWatcher("**/*.{ex,exs,erl,hrl,yrl,xrl,eex,leex,heex,sface}"),
       ],
     },
   };
 
   function didOpenTextDocument(document: vscode.TextDocument): void {
-    // We are only interested in elixir files
-    if (document.languageId !== "elixir") {
+    // We are only interested in elixir related files
+    if (["elixir", "eex", "html-eex", "phoenix-heex", "surface"].indexOf(document.languageId) < 0) {
       return;
     }
 
@@ -394,14 +398,16 @@ export function activate(context: ExtensionContext): void {
 
     // If we have nested workspace folders we only start a server on the outer most workspace folder.
     folder = getOuterMostWorkspaceFolder(folder);
-    
+
     if (!clients.has(folder.uri.toString())) {
       const pattern = `${folder.uri.fsPath}/**/*`
       // open untitled files go to the first workspace
       const untitled = folder.index === 0 ? [
         { language: "elixir", scheme: "untitled" },
         { language: "eex", scheme: "untitled" },
-        { language: "html-eex", scheme: "untitled"}
+        { language: "html-eex", scheme: "untitled"},
+        { language: "phoenix-heex", scheme: "untitled"},
+        { language: "surface", scheme: "untitled"}
       ] : [];
       const workspaceClientOptions: LanguageClientOptions = Object.assign(
         {},
@@ -412,6 +418,8 @@ export function activate(context: ExtensionContext): void {
             { language: "elixir", scheme: "file", pattern: pattern },
             { language: "eex", scheme: "file", pattern: pattern },
             { language: "html-eex", scheme: "file", pattern: pattern },
+            { language: "phoenix-heex", scheme: "file", pattern: pattern },
+            { language: "surface", scheme: "file", pattern: pattern },
             ...untitled
           ],
           workspaceFolder: folder,
@@ -472,6 +480,6 @@ function getClient(document: vscode.TextDocument): LanguageClient | null {
 
   // If we have nested workspace folders we only start a server on the outer most workspace folder.
   folder = getOuterMostWorkspaceFolder(folder);
-  
+
   return clients.get(folder.uri.toString())!;
 }


### PR DESCRIPTION
This PR along with https://github.com/elixir-lsp/elixir-ls/pull/583 adds support for `HEEx` and `Surface` templates. The changes allow VS Code to:

1. Watch `.heex` and `.sface` files so recompilation is triggered when they change
2. Activate the ElixirLS server when `.heex` or `.sface` files are open (otherwise the server is only initiated when you open an elixir file)
3. Properly show error/warnings when originated in `.heex` or `.sface` files

@lukaszsamson I still have to make some changes in ElixirSense to improve the integration. Currently, suggestions/autocomplete are not aware of the template context so they are mostly considering the whole file as elixir code which brings a poor experience. I'll try to work on that next week. 

Since the changes implemented in this PR have no dependency from any of the planned changes in ElixirSense, they can be applied independently.

@chrismccord this PR also closes https://github.com/elixir-lsp/vscode-elixir-ls/pull/193 as the syntax highlighting was already implemented in https://github.com/phoenixframework/vscode-phoenix.

