### PR TITLE
fix regex highlight with "<"

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -324,9 +324,6 @@
       "patterns": [
         {
           "include": "#regex_sub"
-        },
-        {
-          "include": "#nest_ltgt"
         }
       ]
     },
@@ -348,14 +345,11 @@
       "patterns": [
         {
           "include": "#regex_sub"
-        },
-        {
-          "include": "#nest_ltgt"
         }
       ]
     },
     {
-      "comment": "Regex sigil with single quotes",
+      "comment": "Regex sigil with double quotes heredocs",
       "begin": "~r\\\"\\\"\\\"",
       "beginCaptures": {
         "0": {
@@ -372,9 +366,6 @@
       "patterns": [
         {
           "include": "#regex_sub"
-        },
-        {
-          "include": "#nest_ltgt"
         }
       ]
     },
@@ -396,9 +387,6 @@
       "patterns": [
         {
           "include": "#regex_sub"
-        },
-        {
-          "include": "#nest_ltgt"
         }
       ]
     },
@@ -420,9 +408,6 @@
       "patterns": [
         {
           "include": "#regex_sub"
-        },
-        {
-          "include": "#nest_ltgt"
         }
       ]
     },
@@ -535,12 +520,7 @@
           "name": "punctuation.section.regexp.end.elixir"
         }
       },
-      "name": "string.regexp.literal.elixir",
-      "patterns": [
-        {
-          "include": "#nest_ltgt"
-        }
-      ]
+      "name": "string.regexp.literal.elixir"
     },
     {
       "comment": "Literal regex sigil with single quoted heredoc",
@@ -556,12 +536,7 @@
           "name": "punctuation.section.regexp.end.elixir"
         }
       },
-      "name": "string.regexp.literal.elixir",
-      "patterns": [
-        {
-          "include": "#nest_ltgt"
-        }
-      ]
+      "name": "string.regexp.literal.elixir"
     },
     {
       "comment": "Literal regex sigil with double quoted heredoc",
@@ -577,12 +552,7 @@
           "name": "punctuation.section.regexp.end.elixir"
         }
       },
-      "name": "string.regexp.literal.elixir",
-      "patterns": [
-        {
-          "include": "#nest_ltgt"
-        }
-      ]
+      "name": "string.regexp.literal.elixir"
     },
     {
       "comment": "Literal regex sigil with double quotes",
@@ -598,12 +568,7 @@
           "name": "punctuation.section.regexp.end.elixir"
         }
       },
-      "name": "string.regexp.literal.elixir",
-      "patterns": [
-        {
-          "include": "#nest_ltgt"
-        }
-      ]
+      "name": "string.regexp.literal.elixir"
     },
     {
       "comment": "Literal regex sigil with single quotes",
@@ -619,12 +584,7 @@
           "name": "punctuation.section.regexp.end.elixir"
         }
       },
-      "name": "string.regexp.literal.elixir",
-      "patterns": [
-        {
-          "include": "#nest_ltgt"
-        }
-      ]
+      "name": "string.regexp.literal.elixir"
     },
     {
       "comment": "Character list sigil with curlies",


### PR DESCRIPTION
Regex sigils with the delimiters `"`, `'`, `<` and heredoc `"""` and `'''` that have the character `<` don't close correctly and leak to the code after the regex.

[Gist with the code](https://gist.github.com/tiagoefmoraes/5bfcaea5c167d6a0d8639231857a9c07)

Before | After
-|-
![before](https://user-images.githubusercontent.com/1627293/151678442-ff383bef-2003-436c-baca-60e6fa55c98b.png) | ![after](https://user-images.githubusercontent.com/1627293/151678444-efc58b11-38ca-40ec-bc6b-e536a7e6b931.png)
