### PR TITLE
Change elixirLS.mixTarget minLength from 0 to 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
           "scope": "resource",
           "type": "string",
           "description": "Mix target to use for compilation",
-          "minLength": 0
+          "minLength": 1
         },
         "elixirLS.projectDir": {
           "scope": "resource",


### PR DESCRIPTION
This prevents an empty `""` from being used in the target and incorrectly setting it.
https://github.com/elixir-lsp/elixir-ls/pull/670#issuecomment-1026101865

- https://github.com/elixir-lsp/elixir-ls/pull/670
- https://github.com/nerves-project/nerves/issues/694