### PR TITLE
Fix string interpolation highlighting

### DIFF
--- a/syntaxes/eex.json
+++ b/syntaxes/eex.json
@@ -20,7 +20,7 @@
         }
       },
       "end": "-?%>",
-      "name": "source.elixir.embedded",
+      "name": "meta.embedded.line.elixir",
       "patterns": [
         {
           "captures": {

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -2400,11 +2400,11 @@
               "name": "punctuation.section.embedded.elixir"
             },
             "1": {
-              "name": "source.elixir.embedded.source.empty"
+              "name": "meta.embedded.line.empty.elixir"
             }
           },
           "match": "#\\{(\\})",
-          "name": "source.elixir.embedded.source"
+          "name": "meta.embedded.line.elixir"
         },
         {
           "begin": "#\\{",
@@ -2414,7 +2414,7 @@
             }
           },
           "end": "\\}",
-          "name": "source.elixir.embedded.source",
+          "name": "meta.embedded.line.elixir",
           "patterns": [
             {
               "include": "#nest_curly_and_self"


### PR DESCRIPTION
related issue https://github.com/elixir-lsp/vscode-elixir-ls/issues/185

### Current
<img width="302" alt="image" src="https://user-images.githubusercontent.com/6327995/152601466-b1d324b1-0cda-4df5-a3fc-e51a17ae4818.png">

`function name(inspect)`, `variable name(arr)` and `separator(,)` syntax highlighting does not work string interpolation.

### Expected
<img width="299" alt="image" src="https://user-images.githubusercontent.com/6327995/152601650-a5cab8a7-35d3-4b80-9df6-cc15ede4ce66.png">

I compare [elixir syntaxes in TextMate](https://github.com/elixir-editors/elixir-tmbundle/blob/43c8cd957d5ac6e1abbd8730fc7a08c81a6e76c9/Syntaxes/Elixir.tmLanguage#L1520-L1557) and [ruby syntaxes](https://github.com/rubyide/vscode-ruby/blob/b232cfd0c96f41ceab72655dcfa17dab40c05562/packages/vscode-ruby/syntaxes/ruby.cson.json#L2280-L2305) and try to solve.

