### PR TITLE
Add syntax rule for typespec definitions

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -88,6 +88,12 @@
       ]
     },
     {
+      "begin": "@(spec)\\s",
+      "end": "(?=^\\s*(@|def))",
+      "comment": "Typespec definition",
+      "name": "entity.name.typespec.elixir"
+    },
+    {
       "match": "(?<!\\.)\\b(alias|require|import|use)\\b(?![?!])",
       "name": "keyword.other.special-method.elixir"
     },

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -88,7 +88,7 @@
       ]
     },
     {
-      "begin": "@(spec)\\s",
+      "begin": "@(spec|typep?|opaque|callback|macrocallback)\\s",
       "end": "(?=^\\s*(@|def))",
       "comment": "Typespec definition",
       "name": "entity.name.typespec.elixir"


### PR DESCRIPTION
# Problem

Typespec rules are not recognised as an independent syntax token. 

I was following PR #12 , a request to add syntax highlighting for `@spec` definitions. That issue was closed with the following reason: 

> However this can be accomplished for you locally with a local override: https://code.visualstudio.com/docs/getstarted/themes#_customizing-a-color-theme 

This comment is incorrect. You can see that VSCode tokenizes `@spec` as `variable.other.readwrite.module.elixir`. There is no specific tokenization rule for typespecs, therefore no way to create a local override. 

![Screenshot 2022-09-02 at 13 28 18](https://user-images.githubusercontent.com/7713/188142810-1cc3a1b1-1635-4634-b22e-471ab7eae2db.png)

# Solution

I agree with @axelson in #12: typespecs aren't comments. So this PR adds an entirely new rule: `entity.name.typespec.elixir`. 

This means that there are zero visual changes for users, nothing changes until you add a custom local override.

I use the following settings: 

```json
    "editor.tokenColorCustomizations": {
        "[Dracula]": {
            "keywords": "#80516b",
            "textMateRules": [
                {
                    "scope": "entity.name.typespec.elixir ",
                    "settings": {
                        "foreground": "#80516b",
                    }
                }
            ],
        }
    }
```

Which looks like this: 

![Screenshot 2022-09-02 at 13 21 32](https://user-images.githubusercontent.com/7713/188143617-3f006a2e-f8a7-4f36-b846-869852933919.png)

This change focusses only on spec definitions, not type definitons or anything else. 