### PR TITLE
Highlights defdelegate as a function definition

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -102,12 +102,12 @@
       "name": "constant.language.symbol.elixir"
     },
     {
-      "match": "(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|defguardp?|exit|after|rescue|catch|else|raise|throw|quote|unquote|unquote_splicing|super|when|and|or|not|in)\\b(?![?!])",
+      "match": "(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defcallback|defexception|defoverridable|defguardp?|exit|after|rescue|catch|else|raise|throw|quote|unquote|unquote_splicing|super|when|and|or|not|in)\\b(?![?!])",
       "name": "keyword.control.elixir"
     },
     {
       "comment": "Function with parameters",
-      "begin": "\\b(defp?|defmacrop?)\\b\\s*([_$a-z][$\\w]*[!?]?)\\s*\\(",
+      "begin": "\\b(defp?|defmacrop?|defdelegate)\\b\\s*([_$a-z][$\\w]*[!?]?)\\s*\\(",
       "name": "meta.function.definition.elixir",
       "beginCaptures": {
         "1": {
@@ -129,7 +129,7 @@
     },
     {
       "comment": "Function without parameters",
-      "match": "\\b(defp?|defmacrop?)\\b\\s*([_$a-z][$\\w]*[!?]?)",
+      "match": "\\b(defp?|defmacrop?|defdelegate)\\b\\s*([_$a-z][$\\w]*[!?]?)",
       "name": "meta.function.definition.elixir",
       "captures": {
         "1": {


### PR DESCRIPTION
This pull request updates [Kernel.defdelegate/2](https://hexdocs.pm/elixir/1.14.3/Kernel.html#defdelegate/2) to be highlighted as a function definition instead of as a control keyword.  

From [hexdocs.pm](https://hexdocs.pm/elixir/1.14.3/Kernel.html#defdelegate/2):
> `defdelegate(funs, opts)`
>
> Defines a function that delegates to another module.
>
> _(...)_
>
> Delegation only works with functions; delegating macros is not supported.
>

The change especially helps themes that have different colors for function definitions and control keywords - such as [One Monokai](https://marketplace.visualstudio.com/items?itemName=azemoh.one-monokai), [Dracula](https://marketplace.visualstudio.com/items?itemName=dracula-theme.theme-dracula), [One Dark Pro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme), etc.

## Screenshots

Screenshots from VSCode using the [One Monokai theme](https://marketplace.visualstudio.com/items?itemName=azemoh.one-monokai).

#### Before this pull request

<img width="719" alt="image" src="https://user-images.githubusercontent.com/5060004/217709118-eaaeb834-d873-4c43-ba16-3812a73c904c.png">

#### After this pull request

<img width="719" alt="image" src="https://user-images.githubusercontent.com/5060004/217709280-1071e5a9-8ed2-468c-9ac4-44aa6fe6fc7f.png">
