### PR TITLE
fix(scripts): add ELS_SCRIPT to language_server.sh and debugger.sh

### DIFF
--- a/elixir-ls-release/debugger.sh
+++ b/elixir-ls-release/debugger.sh
@@ -18,4 +18,6 @@ else
 fi
 
 export ELS_MODE=debugger
+export ELS_SCRIPT="ElixirLS.Debugger.CLI.main()"
+
 exec "${dir}/launch.sh"

--- a/elixir-ls-release/language_server.sh
+++ b/elixir-ls-release/language_server.sh
@@ -18,4 +18,6 @@ else
 fi
 
 export ELS_MODE=language_server
+export ELS_SCRIPT="ElixirLS.LanguageServer.CLI.main()"
+
 exec "${dir}/launch.sh"


### PR DESCRIPTION
This fixes an issue when setting the ELS_INSTALL_PREFIX to a custom install without the launch.ex the server exits immediately immediately.

Those variables are already set in the respective upstream elixir-ls scripts, and will be overridden anyway by the launch.ex if if there is no custom ELS_INSTALL_PREFIX.