### PR TITLE
Fix syntax highlighting incorrectly

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -203,7 +203,7 @@
     },
     {
       "comment": "Function call without parenthesis",
-      "match": "([A-Z]\\w+)\\s*(\\.)\\s*([a-z_]\\w*[!?]?)",
+      "match": "\\b([A-Z]\\w+)\\s*(\\.)\\s*([a-z_]\\w*[!?]?)",
       "captures": {
         "1": {
           "name": "variable.other.constant.elixir"


### PR DESCRIPTION
resolve #347 

Inspect Editor Tokens and Scopes in vscode
- Before
<img width="500" alt="image" src="https://github.com/elixir-lsp/vscode-elixir-ls/assets/6327995/4245fac9-a0f4-43c6-b07e-bc99b0f626c9">

And I inspected the `snake_case` case
<img width="500" alt="image" src="https://github.com/elixir-lsp/vscode-elixir-ls/assets/6327995/3ae34b2c-576c-4665-aa5b-745824bea0f4">

- After
<img width="500" alt="image" src="https://github.com/elixir-lsp/vscode-elixir-ls/assets/6327995/67911fdf-e36e-4796-9277-464428407d85">