### PR TITLE
Renamed '&' operator to keyword.operator.other.anonymous.elixir

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -351,7 +351,7 @@
       "match": "(\\&)([_\\p{Ll}\\p{Lo}][\\p{L}\\p{N}_]*[?!]?)(\\/)([0-9]+)",
       "captures": {
         "1": {
-          "name": "keyword.operator.other.elixir"
+          "name": "keyword.operator.other.anonymous.elixir"
         },
         "2": {
           "name": "entity.name.function.call.capture.elixir"
@@ -2529,7 +2529,7 @@
     },
     {
       "match": "(&)",
-      "name": "keyword.operator.other.elixir"
+      "name": "keyword.operator.other.anonymous.elixir"
     },
     {
       "captures": {


### PR DESCRIPTION
Hey guys,

I need the operator `&` to have specific name, for code highlighting customizations.
Is this the best way to do this?

If everything is fine I'd appreciate to have this change in next versions.

Thank you very much!