### PR TITLE
feat: improve terminal file link handling

### DIFF
--- a/src/terminalLinkProvider.ts
+++ b/src/terminalLinkProvider.ts
@@ -51,8 +51,9 @@ export function configureTerminalLinkProvider(
       data: { app, file, line },
     }: TerminalLinkWithData) => {
       const umbrellaFile = path.join("apps", app, file);
+      const depsFile = path.join("deps", app, file);
       const uris = await vscode.workspace.findFiles(
-        `{${umbrellaFile},${file}}`
+        `{${umbrellaFile},${file},${depsFile}}`
       );
       if (uris.length === 1) {
         openUri(uris[0], line);

--- a/src/terminalLinkProvider.ts
+++ b/src/terminalLinkProvider.ts
@@ -29,7 +29,7 @@ export function configureTerminalLinkProvider(
       _token: vscode.CancellationToken
     ): vscode.ProviderResult<TerminalLinkWithData[]> => {
       const regex =
-        /(?:\((?<app>[_a-z]+) \d+.\d+.\d+\) )(?<file>[_a-z/]*[_a-z]+.ex):(?<line>\d+)/;
+        /(?:\((?<app>[_a-z0-9]+) \d+.\d+.\d+\) )(?<file>[_a-z0-9/]*[_a-z0-9]+.ex):(?<line>\d+)/;
       const matches = context.line.match(regex);
       if (matches === null) {
         return [];


### PR DESCRIPTION
Hi and thanks for a great library.

I ran into a couple of instances where the extension wasn't generating terminal links or opening them correctly. Here is my attempt at fixing them within the current implementation.

- workspace dependencies
  I hard-coded the "deps" path prefix in the same way as the umbrella "apps" path so 
- absolute paths
- deps and paths with numbers

The first video is the current functionality and the second shows all 3 fixed links.

https://github.com/elixir-lsp/vscode-elixir-ls/assets/4416345/5e01c08b-fed2-42e0-8e13-6ca788f15f84


https://github.com/elixir-lsp/vscode-elixir-ls/assets/4416345/41c0478a-c352-4ca1-9bb6-ef1a9e4fe655

