### PR TITLE
Allow to restrict looking for the mix.exs in the current workspace root only, closes #424

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Unreleased
 
+#### Highlights
+
+- Allow to restrict projectDir detection to the current workspace root folder only
+
+#### Improvements
+
+- It is possible to restrict `mix.exs` search (projectDir) to the current root folder only, so in multi-root workspace configurations ElixirLS won't start in the outermost containing the `mix.exs` folder
+
+
 ### v0.22.0: 11 June 2024
 
 #### Highlights

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you run into issues with the extension, try these debugging steps:
 - After stopping your editor, remove the entire `.elixir_ls` directory, then restart your editor.
   - NOTE: This will cause you to have to re-run the entire dialyzer build
 
-You may need to set `elixirLS.mixEnv`, `elixirLS.mixTarget`, and `elixirLS.projectDir` if your project requires it. By default, ElixirLS compiles code with `MIX_ENV=test`, `MIX_TARGET=host`, and assumes that `mix.exs` is located in the workspace root directory.
+You may need to set `elixirLS.mixEnv`, `elixirLS.mixTarget`, `elixirLS.projectDir` and/or `elixirLS.useCurrentRootFolderAsProjectDir` if your project requires it. By default, ElixirLS compiles code with `MIX_ENV=test`, `MIX_TARGET=host`, and assumes that `mix.exs` is located in the workspace root directory.
 
 If you get an error like the following immediately on startup:
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "The Elixir community",
   "license": "MIT",
   "publisher": "JakeBecker",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "engines": {
     "vscode": "^1.85.0"
   },
@@ -164,6 +164,12 @@
           "description": "Subdirectory containing Mix project if not in the project root",
           "minLength": 0,
           "default": ""
+        },
+        "elixirLS.useCurrentRootFolderAsProjectDir": {
+          "scope": "resource",
+          "type": "boolean",
+          "description": "Don't try to look for mix.exs in parent directories",
+          "default": false
         },
         "elixirLS.fetchDeps": {
           "scope": "resource",

--- a/src/project.ts
+++ b/src/project.ts
@@ -58,9 +58,16 @@ export class WorkspaceTracker {
       uri = uri + "/";
     }
 
+    const useCurrentRootFolderAsProjectDir = vscode.workspace
+      .getConfiguration("elixirLS", folder)
+      .get<boolean>("useCurrentRootFolderAsProjectDir");
+
+
     let outermostFolder: vscode.WorkspaceFolder | null = null;
 
-    for (const element of this.sortedWorkspaceFolders()) {
+    const sortedWorkspaceFolders = useCurrentRootFolderAsProjectDir ? [uri] : this.sortedWorkspaceFolders();
+
+    for (const element of sortedWorkspaceFolders) {
       if (uri.startsWith(element)) {
         const foundFolder = vscode.workspace.getWorkspaceFolder(
           vscode.Uri.parse(element)

--- a/src/test-fixtures/containing_folder_with_mix/mix.exs
+++ b/src/test-fixtures/containing_folder_with_mix/mix.exs
@@ -1,0 +1,28 @@
+defmodule SingleFolderMix.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :containing_folder_with_mix,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/src/test-fixtures/containing_folder_with_mix/single_folder_mix/.formatter.exs
+++ b/src/test-fixtures/containing_folder_with_mix/single_folder_mix/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/src/test-fixtures/containing_folder_with_mix/single_folder_mix/.gitignore
+++ b/src/test-fixtures/containing_folder_with_mix/single_folder_mix/.gitignore
@@ -1,0 +1,26 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+single_folder_mix-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/src/test-fixtures/containing_folder_with_mix/single_folder_mix/README.md
+++ b/src/test-fixtures/containing_folder_with_mix/single_folder_mix/README.md
@@ -1,0 +1,20 @@
+# SingleFolderMix
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `single_folder_mix` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:single_folder_mix, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at <https://hexdocs.pm/single_folder_mix>.

--- a/src/test-fixtures/containing_folder_with_mix/single_folder_mix/lib/single_folder_mix.ex
+++ b/src/test-fixtures/containing_folder_with_mix/single_folder_mix/lib/single_folder_mix.ex
@@ -1,0 +1,18 @@
+defmodule SingleFolderMix do
+  @moduledoc """
+  Documentation for `SingleFolderMix`.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> SingleFolderMix.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/src/test-fixtures/containing_folder_with_mix/single_folder_mix/mix.exs
+++ b/src/test-fixtures/containing_folder_with_mix/single_folder_mix/mix.exs
@@ -1,0 +1,28 @@
+defmodule SingleFolderMix.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :single_folder_mix,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/src/test-fixtures/containing_folder_with_mix/single_folder_mix/test/single_folder_mix_test.exs
+++ b/src/test-fixtures/containing_folder_with_mix/single_folder_mix/test/single_folder_mix_test.exs
@@ -1,0 +1,8 @@
+defmodule SingleFolderMixTest do
+  use ExUnit.Case
+  doctest SingleFolderMix
+
+  test "greets the world" do
+    assert SingleFolderMix.hello() == :world
+  end
+end

--- a/src/test-fixtures/containing_folder_with_mix/single_folder_mix/test/test_helper.exs
+++ b/src/test-fixtures/containing_folder_with_mix/single_folder_mix/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/src/test/multiRoot/extension.test.ts
+++ b/src/test/multiRoot/extension.test.ts
@@ -227,4 +227,36 @@ suite("Multi root workspace tests", () => {
       )
     );
   }).timeout(30000);
+
+  test("extension starts first client on the same folder with mix.exs if useCurrentRootFolderAsProjectDir is true", async () => {
+    vscode.workspace.getConfiguration("elixirLS").update("useCurrentRootFolderAsProjectDir", true, vscode.ConfigurationTarget.WorkspaceFolder);
+
+    const fileUri = vscode.Uri.file(
+      path.join(
+        fixturesPath,
+        "containing_folder",
+        "single_folder_mix",
+        "mix.exs"
+      )
+    );
+
+    const workspaceFolderUri = vscode.Uri.file(
+      path.join(fixturesPath, "containing_folder", "single_folder_mix")
+    );
+
+    await waitForLanguageClientManagerUpdate(extension, async () => {
+      const document = await vscode.workspace.openTextDocument(fileUri);
+      await vscode.window.showTextDocument(document);
+    });
+
+    assert.ok(!extension.exports.languageClientManager.defaultClient);
+    assert.equal(extension.exports.languageClientManager.clients.size, 3);
+
+    assert.equal(
+      extension.exports.languageClientManager.getClientByUri(fileUri),
+      extension.exports.languageClientManager.clients.get(
+        workspaceFolderUri.toString()
+      )
+    );
+  }).timeout(30000);
 });

--- a/telemetry.json
+++ b/telemetry.json
@@ -135,6 +135,7 @@
     },
     "lsp_config": {
       "elixir_ls.projectDir":                 {"classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Is project dir overriden"},
+      "elixir_ls.useCurrentRootFolderAsProjectDir": {"classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Is project dir set to the current root in multi-root workspace"},
       "elixir_ls.autoBuild":                  {"classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Is auto build enabled"},
       "elixir_ls.dialyzerEnabled":            {"classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Is dialyzer enabled"},
       "elixir_ls.fetchDeps":                  {"classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Is auto fetching of dependencies enabled"},


### PR DESCRIPTION
Addresses #424