### PR TITLE
Pass shell option to prevent EINVAL error when starting client

### DIFF
--- a/src/languageClientManager.ts
+++ b/src/languageClientManager.ts
@@ -50,6 +50,7 @@ function startClient(
       "language_server",
       clientOptions.workspaceFolder
     ),
+    options: { shell: true },
   };
 
   // If the extension is launched in debug mode then the `debug` server options are used instead of `run`


### PR DESCRIPTION
Fixing CVE-2024-27980 in Node.js introduced a breaking change for Windows users who utilize child_process.spawn and child_process.spawnSync. Node.js will now error with EINVAL if a .bat or .cmd file is passed to child_process.spawn and child_process.spawnSync without the shell option set. If the input to spawn/spawnSync is sanitized, users can now pass { shell: true } as an option to prevent the occurrence of EINVALs errors.