### PR TITLE
Handle embedded-content

### DIFF
--- a/src/languageClientManager.ts
+++ b/src/languageClientManager.ts
@@ -15,10 +15,21 @@ import {
   reporter,
 } from "./telemetry";
 
-const languageIds = ["elixir", "eex", "html-eex", "phoenix-heex", "surface"];
+// Languages fully handled by this extension
+const languageIds = ["elixir", "eex", "html-eex", "phoenix-heex"];
+
+// Template languages handled by their own extensions but require activation of this
+// one for compiler diagnostics. Template languages that compile down to Elixir AST
+// and embed other languages (e.g. HTML, CSS, JS and Elixir itself), should be moved
+// here for proper language service forwarding via "embedded-content".
+const templateLanguageIds = ["surface"];
+
+const activationLanguageIds = languageIds.concat(templateLanguageIds);
+
 const defaultDocumentSelector = languageIds.flatMap((language) => [
   { language, scheme: "file" },
   { language, scheme: "untitled" },
+  { language, scheme: "embedded-content" },
 ]);
 
 const untitledDocumentSelector = languageIds.map((language) => ({
@@ -348,7 +359,7 @@ export class LanguageClientManager {
     context: vscode.ExtensionContext,
   ) {
     // We are only interested in elixir related files
-    if (!languageIds.includes(document.languageId)) {
+    if (!activationLanguageIds.includes(document.languageId)) {
       return;
     }
 


### PR DESCRIPTION
Related to https://github.com/elixir-lsp/vscode-elixir-ls/issues/278.

Currently, `vscode-elixir-ls` handles all template languages without parsing them, which brings a problem that all services, including code completion, hover, go to definition, etc. don't work as expected. Ideally, each template-specific extension should handle their own template and then forward to other services when required, for instance, when inside `<style>`, `<script>` or elixir expressions inside `{ }` or `<% %>`.

This PR adds the `"embedded-content"` scheme to the list of `documentSelector` for all languages handled by this extension. This allows any other extension to properly forward any Elixir-related command to be handled by ElixirLS only when actually necessary.

Ideally, this extension (or the next official one) should only handle Elixir language. This way it can work consistently, without having to parse each individual template language. All other templates that have their own syntax should be responsible for handling their own LS requests, even if they, eventually, have to forward the request back to this extension.

A couple of examples of inconsistent code completions, listing Elixir-related suggestions where it shouldn't:

### Inside `<style>`

![image](https://github.com/user-attachments/assets/66d5f3f4-fe2b-40a9-8c28-47f4045fd6e8)

### Inside `<script>`

![image](https://github.com/user-attachments/assets/c632c957-fd38-4591-99e1-077e27f2d0b8)

### Inside HTML markup

![image](https://github.com/user-attachments/assets/4159754e-b643-4bea-b25c-e1df582a0800)

By properly dealing with `embedded-content`, other extensions can handle their own templates, detect other embedded languages and then forward to the proper service. The service is handle by whatever extension the user has installed that is registered to handle the content type.

Here's an example using the Surface extension, which avoids bringing all the suggestions from ElixirLS, even when it makes no sense:

### Listing only applicable components and HTML tags

![image](https://github.com/user-attachments/assets/0c8985db-a727-468a-b1a0-47b8d111ad12)

### Forwarding to Elixir service when inside expressions

![image](https://github.com/user-attachments/assets/03437be3-855b-42c6-837b-c57eea6a38b8)

### Forwarding to CSS/Tailwind service when inside `<style>`

![image](https://github.com/user-attachments/assets/1d15edf0-03bc-46f9-9d4c-81c5910547cf)

The `vscode-elixir-ls` should do the same when working with embedded templates using `~H` or `~F`. But that should be addressed on a separate PR.
