### PR TITLE
Fix Windows path replacement in runTest

### DIFF
--- a/src/commands/runTest.ts
+++ b/src/commands/runTest.ts
@@ -250,7 +250,7 @@ function buildTestCommandArgs(args: RunTestArgs, debug: boolean): string[] {
     // TODO remove this when we require elixir 1.17
     const path =
       os.platform() === "win32"
-        ? args.filePath.replace("\\", "/")
+        ? args.filePath.replace(/\\/g, "/")
         : args.filePath;
     result.push(`${path}${line}`);
   }


### PR DESCRIPTION
## Summary
- fix test path replacement when running on Windows

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_e_6848a7bf15b4832193afe3816bb689b5