### PR TITLE
Fix terminal link regex

### DIFF
--- a/src/terminalLinkProvider.ts
+++ b/src/terminalLinkProvider.ts
@@ -27,7 +27,7 @@ export function configureTerminalLinkProvider(
       _token: vscode.CancellationToken,
     ): vscode.ProviderResult<TerminalLinkWithData[]> => {
       const regex =
-        /(?:\((?<app>[_a-z0-9]+) \d+.\d+.\d+\) )(?<file>[_a-z0-9/]*[_a-z0-9]+.ex):(?<line>\d+)/;
+        /(?:\((?<app>[_a-z0-9]+) \d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?\) )(?<file>[_a-z0-9/]*[_a-z0-9]+\.ex):(?<line>\d+)/;
       const matches = context.line.match(regex);
       if (matches === null) {
         return [];


### PR DESCRIPTION
## Summary
- properly escape dots in terminal link provider to match version numbers
- allow optional pre-release suffixes like `-rc.0`

## Testing
- `npx biome check src/terminalLinkProvider.ts`
- `npm test --silent` *(fails: Test run terminated with signal SIGSEGV)*

------
https://chatgpt.com/codex/tasks/task_e_6848b1b5396483219b2ece65ea8e03f6