### PR TITLE
Enable test for non workspace file

### DIFF
--- a/src/test/multiRoot/extension.test.ts
+++ b/src/test/multiRoot/extension.test.ts
@@ -100,14 +100,15 @@ suite("Multi root workspace tests", () => {
     );
   });
 
-  // TODO throw or return null
-  // test("requests from non workspace file: docs go to first workspace client", async () => {
-  //   const fileUri = vscode.Uri.file(path.join(fixturesPath, "elixir_file.ex"));
-  //   assert.equal(
-  //     languageClientManager.getClientByUri(fileUri),
-  //     languageClientManager.clients.get(vscode.workspace.workspaceFolders![0].uri.toString())
-  //   );
-  // });
+  test("requests from non workspace file: docs go to first workspace client", async () => {
+    const fileUri = vscode.Uri.file(path.join(fixturesPath, "elixir_file.ex"));
+    assert.equal(
+      extension.exports.languageClientManager.getClientByUri(fileUri),
+      extension.exports.languageClientManager.clients.get(
+        vscode.workspace.workspaceFolders?.[0].uri.toString() ?? "",
+      ),
+    );
+  });
 
   test("extension starts second client on file open from different outermost folder", async () => {
     const fileUri = vscode.Uri.file(


### PR DESCRIPTION
## Summary
- enable the test that checks requests from files outside the workspace

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848b1dd4a2483218376a17de8a29815