### PR TITLE
Fix typo in comment

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -94,7 +94,7 @@ export class WorkspaceTracker {
       return outermostFolder;
     }
 
-    // most likely handleDidChangeWorkspaceFolders callback hs not yet run
+    // most likely handleDidChangeWorkspaceFolders callback has not yet run
     // clear cache and try again
     if (!isRetry) {
       this.handleDidChangeWorkspaceFolders();


### PR DESCRIPTION
## Summary
- correct minor typo in a workspace folder comment

## Testing
- `npm run lint`
- `npm test` *(fails: output truncated due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6848b1f1f9608321bbf4f6973cb79560