### PR TITLE
Fix launch config retrieval

### DIFF
--- a/src/commands/runTest.ts
+++ b/src/commands/runTest.ts
@@ -32,9 +32,19 @@ function getExistingLaunchConfig(
     "launch",
     args.workspaceFolder,
   );
-  const testConfig = launchJson.configurations.findLast(
-    (e: { name: string }) => e.name === "mix test",
+  const configurations = launchJson.get<vscode.DebugConfiguration[]>(
+    "configurations",
   );
+  let testConfig: vscode.DebugConfiguration | undefined;
+  if (Array.isArray(configurations)) {
+    for (let i = configurations.length - 1; i >= 0; i--) {
+      const c = configurations[i];
+      if (c?.name === "mix test") {
+        testConfig = c;
+        break;
+      }
+    }
+  }
 
   if (testConfig === undefined) {
     return undefined;


### PR DESCRIPTION
## Summary
- fix retrieval of existing launch config in `runTest`

## Testing
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848b7ff3aec83218c49edb21d993b39