### PR TITLE
Fix comment in test controller

### DIFF
--- a/src/testController.ts
+++ b/src/testController.ts
@@ -160,7 +160,7 @@ export function configureTestController(
         (segment) => segment === "node_modules" || segment.startsWith("."),
       )
     ) {
-      // exclude phoenix tests in node_module
+      // exclude phoenix tests in node_modules
       return false;
     }
 


### PR DESCRIPTION
## Summary
- fix misspelling in test controller comment

## Testing
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_6848b844f20c8321bf6cd8ed433b9b98