### PR TITLE
Replace sleep with event wait in nested workspace test

### DIFF
--- a/src/test/multiRoot/extension.test.ts
+++ b/src/test/multiRoot/extension.test.ts
@@ -66,10 +66,10 @@ suite("Multi root workspace tests", () => {
     const fileUri = vscode.Uri.file(
       path.join(fixturesPath, "sample_umbrella", "apps", "child1", "mix.exs"),
     );
-    const document = await vscode.workspace.openTextDocument(fileUri);
-    await vscode.window.showTextDocument(document);
-
-    await sleep(3000);
+    await waitForLanguageClientManagerUpdate(extension, async () => {
+      const document = await vscode.workspace.openTextDocument(fileUri);
+      await vscode.window.showTextDocument(document);
+    });
 
     assert.ok(!extension.exports.languageClientManager.defaultClient);
     assert.equal(extension.exports.languageClientManager.clients.size, 1);


### PR DESCRIPTION
## Summary
- use `waitForLanguageClientManagerUpdate` instead of `sleep` in the nested workspace test

## Testing
- `xvfb-run -a npm test` *(fails: Failed to run elixir check command)*

------
https://chatgpt.com/codex/tasks/task_e_6848b86ac2f083218f221e182c014a98