### PR TITLE
Fix unhandled promise in test controller

### DIFF
--- a/src/testController.ts
+++ b/src/testController.ts
@@ -170,7 +170,7 @@ export function configureTestController(
   function parseTestsInDocument(e: vscode.TextDocument) {
     const projectDir = workspaceTracker.getProjectDirForUri(e.uri);
     if (projectDir && filterTestFile(e.uri, projectDir)) {
-      parseTestsInFileContents(getOrCreateFile(e.uri, projectDir));
+      void parseTestsInFileContents(getOrCreateFile(e.uri, projectDir));
     }
   }
 


### PR DESCRIPTION
## Summary
- prevent unhandled rejections when parsing tests on document open

## Testing
- `npm run -s compile`
- `node ./out/test/runTest.js` *(fails: platform failed to initialize)*

------
https://chatgpt.com/codex/tasks/task_e_6848b83125d4832182e26aee6ee84f0d