### PR TITLE
Replace sleep delays in nested workspace test

### DIFF
--- a/src/test/multiRoot/extension.test.ts
+++ b/src/test/multiRoot/extension.test.ts
@@ -8,8 +8,8 @@ import type { ElixirLS } from "../../extension";
 import { WorkspaceMode } from "../../project";
 import {
   getExtension,
-  sleep,
   waitForLanguageClientManagerUpdate,
+  waitForNoLanguageClientManagerUpdate,
   waitForWorkspaceUpdate,
 } from "../utils";
 
@@ -180,10 +180,10 @@ suite("Multi root workspace tests", () => {
     const fileUri = vscode.Uri.file(
       path.join(fixturesPath, "sample_umbrella", "apps", "child2", "mix.exs"),
     );
-    const document = await vscode.workspace.openTextDocument(fileUri);
-    await vscode.window.showTextDocument(document);
-
-    await sleep(3000);
+    await waitForNoLanguageClientManagerUpdate(extension, async () => {
+      const document = await vscode.workspace.openTextDocument(fileUri);
+      await vscode.window.showTextDocument(document);
+    });
 
     assert.ok(!extension.exports.languageClientManager.defaultClient);
     assert.equal(extension.exports.languageClientManager.clients.size, 2);
@@ -196,7 +196,7 @@ suite("Multi root workspace tests", () => {
       vscode.workspace.updateWorkspaceFolders(addedWorkspaceFolder.index, 1);
     });
 
-    await sleep(3000);
+    await waitForNoLanguageClientManagerUpdate(extension, () => {});
 
     assert.equal(extension.exports.languageClientManager.clients.size, 2);
   }).timeout(30000);

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -63,3 +63,28 @@ export const waitForLanguageClientManagerUpdate = (
       reject(e);
     }
   });
+
+export const waitForNoLanguageClientManagerUpdate = (
+  extension: vscode.Extension<ElixirLS>,
+  fun: () => void,
+  timeout = 3000,
+) =>
+  new Promise<void>((resolve, reject) => {
+    const disposable = extension.exports.languageClientManager.onDidChange(
+      () => {
+        disposable.dispose();
+        reject(new Error("language client manager changed"));
+      },
+    );
+    try {
+      fun();
+    } catch (e) {
+      disposable.dispose();
+      reject(e);
+      return;
+    }
+    setTimeout(() => {
+      disposable.dispose();
+      resolve();
+    }, timeout);
+  });


### PR DESCRIPTION
## Summary
- replace `sleep` usage with new `waitForNoLanguageClientManagerUpdate`
- use event-driven waits in nested workspace test

## Testing
- `npx biome check src/test/utils.ts src/test/multiRoot/extension.test.ts`
- `npm test` *(fails: Test run terminated with signal SIGSEGV)*

------
https://chatgpt.com/codex/tasks/task_e_684933be81a88321b110074aee3f103e