### PR TITLE
Fix extension detection test strings

### DIFF
--- a/src/test/multiRoot/extension.test.ts
+++ b/src/test/multiRoot/extension.test.ts
@@ -23,7 +23,7 @@ suite("Multi root workspace tests", () => {
     extension = getExtension();
   });
 
-  test("extension detects mix.exs and actives", async () => {
+  test("extension detects mix.exs and activates", async () => {
     assert.ok(extension.isActive);
     assert.equal(
       extension.exports.workspaceTracker.mode,

--- a/src/test/singleFolderMix/extension.test.ts
+++ b/src/test/singleFolderMix/extension.test.ts
@@ -20,7 +20,7 @@ suite("Single folder no mix tests", () => {
     extension = getExtension();
   });
 
-  test("extension detects mix.exs and actives", async () => {
+  test("extension detects mix.exs and activates", async () => {
     assert.ok(extension.isActive);
     assert.equal(
       extension.exports.workspaceTracker.mode,


### PR DESCRIPTION
## Summary
- fix typos in the test descriptions referencing extension activation

## Testing
- `CI=true npm test --silent` *(fails: Test run terminated with signal SIGSEGV)*

------
https://chatgpt.com/codex/tasks/task_e_6849335764c4832194a7533701e50400