### PR TITLE
Handle workspace folder removal for test watchers

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,10 @@ import { WorkspaceTracker } from "./project";
 import { TaskProvider } from "./taskProvider";
 import { configureTelemetry, reporter } from "./telemetry";
 import { configureTerminalLinkProvider } from "./terminalLinkProvider";
-import { configureTestController } from "./testController";
+import {
+  configureTestController,
+  handleWorkspaceFolderRemoved as handleTestControllerWorkspaceFolderRemoved,
+} from "./testController";
 import { testElixir } from "./testElixir";
 
 console.log("ElixirLS: Loading extension");
@@ -78,6 +81,7 @@ export function activate(context: vscode.ExtensionContext): ElixirLS {
     vscode.workspace.onDidChangeWorkspaceFolders(async (event) => {
       for (const folder of event.removed) {
         await languageClientManager.handleWorkspaceFolderRemoved(folder);
+        handleTestControllerWorkspaceFolderRemoved(folder);
       }
       // we might have closed client for some nested workspace folder child
       // reopen all needed


### PR DESCRIPTION
## Summary
- track test file watchers per workspace folder
- remove their watchers when a workspace folder is removed

## Testing
- `npm run lint`
- `npm test` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_684933731200832186a8fca5d4bc0136