### PR TITLE
Fix constant to match extension identifier

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
 export const RUN_TEST_FROM_CODELENS = "elixir.lens.test.run";
 
-export const ELIXIR_LS_EXTENSION_NAME = "jakebecker.elixir-ls";
+export const ELIXIR_LS_EXTENSION_NAME = "JakeBecker.elixir-ls";


### PR DESCRIPTION
## Summary
- update `ELIXIR_LS_EXTENSION_NAME` constant to use correct casing

## Testing
- `npm test` *(fails: Test run terminated with signal SIGSEGV)*

------
https://chatgpt.com/codex/tasks/task_e_68493395dbb4832183e59f7e33b33bb1