### PR TITLE
Fix pipe call regex

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -371,7 +371,7 @@
     },
     {
       "comment": "Pipe into no parens local function call",
-      "match": "(?<=\\|\\>\\s*)([_\\p{Ll}\\p{Lo}][\\p{L}\\p{N}_]*[?!]?)",
+      "match": "(?<=\\|\\>)\\s*([_\\p{Ll}\\p{Lo}][\\p{L}\\p{N}_]*[?!]?)",
       "name": "entity.name.function.call.local.pipe.elixir"
     },
     {


### PR DESCRIPTION
## Summary
- update regex for `entity.name.function.call.local.pipe.elixir`

## Testing
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a05f4bcbc83219daa39cc4c53c934