### PR TITLE
Fix telemetry stack property for client stop

### DIFF
--- a/src/languageClientManager.ts
+++ b/src/languageClientManager.ts
@@ -521,7 +521,7 @@ export class LanguageClientManager {
         reporter.sendTelemetryErrorEvent("language_client_stop_error", {
           "elixir_ls.language_client_stop_error": String(e),
           // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-          "elixir_ls.language_client_start_error_stack": (<any>e)?.stack ?? "",
+          "elixir_ls.language_client_stop_error_stack": (<any>e)?.stack ?? "",
         });
       }
       try {
@@ -532,7 +532,7 @@ export class LanguageClientManager {
         reporter.sendTelemetryErrorEvent("language_client_stop_error", {
           "elixir_ls.language_client_stop_error": String(e),
           // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-          "elixir_ls.language_client_start_error_stack": (<any>e)?.stack ?? "",
+          "elixir_ls.language_client_stop_error_stack": (<any>e)?.stack ?? "",
         });
       }
     }


### PR DESCRIPTION
## Summary
- correct stack telemetry property in `handleWorkspaceFolderRemoved`

## Testing
- `npm run lint`
- `npm test` *(fails: produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_684a0ac9ec48832187ee834fb7749baa