### PR TITLE
Fix suite name

### DIFF
--- a/src/test/singleFolderMix/extension.test.ts
+++ b/src/test/singleFolderMix/extension.test.ts
@@ -11,7 +11,7 @@ import { getExtension, waitForLanguageClientManagerUpdate } from "../utils";
 let extension: vscode.Extension<ElixirLS>;
 const fixturesPath = path.resolve(__dirname, "../../../src/test-fixtures");
 
-suite("Single folder no mix tests", () => {
+suite("Single folder mix tests", () => {
   vscode.window.showInformationMessage(
     "Start single folder mix project tests.",
   );


### PR DESCRIPTION
## Summary
- rename `Single folder no mix tests` suite to `Single folder mix tests`

## Testing
- `npm test --silent` *(fails: Missing X server or $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_684a0a9ae9ec83218689be4829aabe02