### PR TITLE
Handle CRLF split in test output

### DIFF
--- a/src/testController.ts
+++ b/src/testController.ts
@@ -394,7 +394,7 @@ export function configureTestController(
   ) {
     // output is a raw terminal, we need to wrap lines with CRLF
     // note replace("\n", "\r\n") is not working correctly
-    for (const line of output.split("\n")) {
+    for (const line of output.split(/\r?\n/)) {
       run.appendOutput(line, undefined, test);
       run.appendOutput("\r\n", undefined, test);
     }


### PR DESCRIPTION
## Summary
- split test output lines on both LF and CRLF in `writeOutput`

## Testing
- `npm run lint`
- `npm test` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_684a0a63364c8321b6bb1f047b189dd6