### PR TITLE
Implement ~BASH and ~b sigil highlighting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,13 @@ jobs:
           # DISABLE_GPU: 1
           ELS_LOCAL: 1
         if: runner.os == 'Linux'
+      - name: Run grammar tests
+        run: |
+          npm run test:grammar
+        env:
+          # DISABLE_GPU: 1
+          ELS_LOCAL: 1
+        if: runner.os != 'Linux'
       - name: Run tests
         run: |
           npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,9 @@
         "mocha": "^11.7.5",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.0",
-        "typescript": "~5.9.3"
+        "typescript": "~5.9.3",
+        "vscode-oniguruma": "^2.0.1",
+        "vscode-textmate": "^9.3.2"
       },
       "engines": {
         "vscode": "^1.99.0"
@@ -4180,6 +4182,20 @@
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-2.0.1.tgz",
+      "integrity": "sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-textmate": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.3.2.tgz",
+      "integrity": "sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -313,7 +313,8 @@
           "entity.name.function.call.dot.elixir"
         ],
         "embeddedLanguages": {
-          "comment.documentation.heredoc.elixir": "markdown"
+          "comment.documentation.heredoc.elixir": "markdown",
+          "source.shell": "shellscript"
         }
       },
       {
@@ -824,6 +825,7 @@
     "update-vscode": "node ./node_modules/vscode/bin/install",
     "pretest": "npm-run-all clean compile",
     "test": "node ./out/test/runTest.js",
+    "test:grammar": "npm run compile && mocha --ui tdd out/test/grammar.test.js",
     "lint": "biome check",
     "fix-formatting": "biome format --write",
     "esbuild-release": "npm run esbuild-base -- --minify",
@@ -843,7 +845,9 @@
     "mocha": "^11.7.5",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.1.0",
-    "typescript": "~5.9.3"
+    "typescript": "~5.9.3",
+    "vscode-oniguruma": "^2.0.1",
+    "vscode-textmate": "^9.3.2"
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^1.2.0",

--- a/src/test/grammar.test.ts
+++ b/src/test/grammar.test.ts
@@ -1,0 +1,324 @@
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { loadWASM, OnigScanner, OnigString } from "vscode-oniguruma";
+import {
+  type IGrammar,
+  INITIAL,
+  type IOnigLib,
+  type IRawGrammar,
+  parseRawGrammar,
+  Registry,
+} from "vscode-textmate";
+
+const REPO_ROOT = path.resolve(__dirname, "../../");
+
+async function createOnigLib(): Promise<IOnigLib> {
+  const wasmPath = path.join(
+    REPO_ROOT,
+    "node_modules/vscode-oniguruma/release/onig.wasm",
+  );
+  const fileBuffer = fs.readFileSync(wasmPath);
+  const wasmBin = fileBuffer.buffer.slice(
+    fileBuffer.byteOffset,
+    fileBuffer.byteOffset + fileBuffer.byteLength,
+  );
+  await loadWASM(wasmBin);
+  return {
+    createOnigScanner: (patterns: string[]) => new OnigScanner(patterns),
+    createOnigString: (s: string) => new OnigString(s),
+  };
+}
+
+function loadGrammarFile(name: string): IRawGrammar {
+  const grammarPath = path.join(REPO_ROOT, "syntaxes", name);
+  const content = fs.readFileSync(grammarPath, "utf8");
+  return parseRawGrammar(content, grammarPath);
+}
+
+function stubShellGrammar(): IRawGrammar {
+  return parseRawGrammar(
+    JSON.stringify({
+      scopeName: "source.shell",
+      patterns: [
+        {
+          match:
+            "\\b(echo|if|then|fi|for|do|done|while|case|esac|function|return|exit|set|export|local)\\b",
+          name: "keyword.control.shell",
+        },
+      ],
+    }),
+    "shell.json",
+  );
+}
+
+async function createRegistry(): Promise<Registry> {
+  const onigLib = createOnigLib();
+  const grammars: Record<string, string> = {
+    "source.elixir": "elixir.json",
+  };
+  return new Registry({
+    onigLib,
+    loadGrammar: async (scopeName: string) => {
+      const file = grammars[scopeName];
+      if (file) {
+        return loadGrammarFile(file);
+      }
+      if (scopeName === "source.shell") {
+        return stubShellGrammar();
+      }
+      return null;
+    },
+  });
+}
+
+/** Tokenize a multi-line string and return all tokens with their scopes. */
+function tokenizeLines(grammar: IGrammar, text: string) {
+  const lines = text.split("\n");
+  let ruleStack = INITIAL;
+  const result: Array<{ line: number; text: string; scopes: string[] }> = [];
+  for (let i = 0; i < lines.length; i++) {
+    const lineTokens = grammar.tokenizeLine(lines[i], ruleStack);
+    for (const token of lineTokens.tokens) {
+      result.push({
+        line: i,
+        text: lines[i].substring(token.startIndex, token.endIndex),
+        scopes: token.scopes,
+      });
+    }
+    ruleStack = lineTokens.ruleStack;
+  }
+  return result;
+}
+
+/** Check that at least one token in the line has a scope matching the predicate. */
+function assertScopeOnLine(
+  tokens: ReturnType<typeof tokenizeLines>,
+  lineIndex: number,
+  scopeSubstring: string,
+  message?: string,
+) {
+  const lineTokens = tokens.filter((t) => t.line === lineIndex);
+  const found = lineTokens.some((t) =>
+    t.scopes.some((s) => s.includes(scopeSubstring)),
+  );
+  assert.ok(
+    found,
+    message ||
+      `Expected scope containing "${scopeSubstring}" on line ${lineIndex}, got scopes: ${JSON.stringify(
+        lineTokens.map((t) => ({ text: t.text, scopes: t.scopes })),
+        null,
+        2,
+      )}`,
+  );
+}
+
+/** Check that no token in the line has a scope matching the predicate. */
+function assertNoScopeOnLine(
+  tokens: ReturnType<typeof tokenizeLines>,
+  lineIndex: number,
+  scopeSubstring: string,
+  message?: string,
+) {
+  const lineTokens = tokens.filter((t) => t.line === lineIndex);
+  const found = lineTokens.some((t) =>
+    t.scopes.some((s) => s.includes(scopeSubstring)),
+  );
+  assert.ok(
+    !found,
+    message ||
+      `Expected no scope containing "${scopeSubstring}" on line ${lineIndex}, but found: ${JSON.stringify(
+        lineTokens
+          .filter((t) => t.scopes.some((s) => s.includes(scopeSubstring)))
+          .map((t) => ({ text: t.text, scopes: t.scopes })),
+        null,
+        2,
+      )}`,
+  );
+}
+
+suite("Bash sigil grammar tests", () => {
+  let grammar: IGrammar;
+
+  suiteSetup(async () => {
+    const registry = await createRegistry();
+    const g = await registry.loadGrammar("source.elixir");
+    if (!g) {
+      throw new Error("Failed to load Elixir grammar");
+    }
+    grammar = g;
+  });
+
+  suite("~b (lowercase, interpolated)", () => {
+    test("heredoc with double quotes gets source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, 'x = ~b"""\necho "hello"\n"""');
+      assertScopeOnLine(tokens, 1, "source.shell");
+    });
+
+    test("heredoc with single quotes gets source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "x = ~b'''\necho 'hello'\n'''");
+      assertScopeOnLine(tokens, 1, "source.shell");
+    });
+
+    test("curlies get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, '~b{echo "hello"}');
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("brackets get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "~b[echo hello]");
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("parens get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "~b(echo hello)");
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("angle brackets get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "~b<echo hello>");
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("pipes get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "~b|echo hello|");
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("slashes get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "~b/echo hello/");
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("double quotes get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, '~b"echo hello"');
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("single quotes get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "~b'echo hello'");
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("supports Elixir interpolation", () => {
+      const tokens = tokenizeLines(grammar, "~b{echo #{name}}");
+      const interpolationTokens = tokens.filter(
+        (t) =>
+          t.line === 0 &&
+          t.scopes.some((s) => s.includes("meta.embedded.line.elixir")),
+      );
+      assert.ok(
+        interpolationTokens.length > 0,
+        `Expected interpolation tokens, got: ${JSON.stringify(
+          tokens
+            .filter((t) => t.line === 0)
+            .map((t) => ({ text: t.text, scopes: t.scopes })),
+          null,
+          2,
+        )}`,
+      );
+    });
+
+    test("accepts flags after closing delimiter", () => {
+      const tokens = tokenizeLines(grammar, "~b{echo hello}Sp");
+      // The key assertion is that tokenization doesn't break -
+      // the closing } with flags should be recognized as the end
+      const endTokens = tokens.filter(
+        (t) =>
+          t.line === 0 &&
+          t.scopes.some((s) => s.includes("punctuation.definition.string.end")),
+      );
+      assert.ok(
+        endTokens.length > 0,
+        "Expected closing delimiter to be recognized",
+      );
+    });
+  });
+
+  suite("~BASH (uppercase, literal)", () => {
+    test("heredoc with double quotes gets source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, 'x = ~BASH"""\necho "hello"\n"""');
+      assertScopeOnLine(tokens, 1, "source.shell");
+    });
+
+    test("heredoc with single quotes gets source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "x = ~BASH'''\necho 'hello'\n'''");
+      assertScopeOnLine(tokens, 1, "source.shell");
+    });
+
+    test("curlies get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, '~BASH{echo "hello"}');
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("brackets get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "~BASH[echo hello]");
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("parens get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "~BASH(echo hello)");
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("angle brackets get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "~BASH<echo hello>");
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("pipes get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "~BASH|echo hello|");
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("slashes get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "~BASH/echo hello/");
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("double quotes get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, '~BASH"echo hello"');
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("single quotes get source.shell scope", () => {
+      const tokens = tokenizeLines(grammar, "~BASH'echo hello'");
+      assertScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("does NOT support Elixir interpolation", () => {
+      const tokens = tokenizeLines(grammar, "~BASH{echo #{name}}");
+      assertNoScopeOnLine(tokens, 0, "meta.embedded.line.elixir");
+    });
+
+    test("accepts flags after closing delimiter", () => {
+      const tokens = tokenizeLines(grammar, "~BASH{echo hello}SEO");
+      const endTokens = tokens.filter(
+        (t) =>
+          t.line === 0 &&
+          t.scopes.some((s) => s.includes("punctuation.definition.string.end")),
+      );
+      assert.ok(
+        endTokens.length > 0,
+        "Expected closing delimiter to be recognized",
+      );
+    });
+  });
+
+  suite("does not interfere with other sigils", () => {
+    test("~r still gets regexp scope", () => {
+      const tokens = tokenizeLines(grammar, "~r{foo.*bar}");
+      assertScopeOnLine(tokens, 0, "string.regexp");
+    });
+
+    test("~s gets generic string scope, not shell", () => {
+      const tokens = tokenizeLines(grammar, "~s{hello world}");
+      assertNoScopeOnLine(tokens, 0, "source.shell");
+    });
+
+    test("~w gets generic string scope, not shell", () => {
+      const tokens = tokenizeLines(grammar, "~w{one two three}");
+      assertNoScopeOnLine(tokens, 0, "source.shell");
+    });
+  });
+});

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -1821,6 +1821,534 @@
       ]
     },
     {
+      "comment": "Bash sigil with double quoted heredoc",
+      "begin": "\\s?(~b\"\"\")$",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "end": "^\\s*(\"\"\"[SEOsvpu]*)$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "source.shell"
+        }
+      ]
+    },
+    {
+      "comment": "Bash sigil with single quoted heredoc",
+      "begin": "\\s?(~b''')$",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "end": "^\\s*('''[SEOsvpu]*)$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "source.shell"
+        }
+      ]
+    },
+    {
+      "comment": "Bash sigil with curlies",
+      "begin": "~b\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\}[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "source.shell"
+        },
+        {
+          "include": "#nest_curly"
+        }
+      ]
+    },
+    {
+      "comment": "Bash sigil with brackets",
+      "begin": "~b\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\][SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "source.shell"
+        },
+        {
+          "include": "#nest_brackets"
+        }
+      ]
+    },
+    {
+      "comment": "Bash sigil with angle brackets",
+      "begin": "~b\\<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\>[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "source.shell"
+        },
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "comment": "Bash sigil with parens",
+      "begin": "~b\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\)[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "source.shell"
+        },
+        {
+          "include": "#nest_parens"
+        }
+      ]
+    },
+    {
+      "comment": "Bash sigil with slashes",
+      "begin": "~b\\/",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\/[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "source.shell"
+        }
+      ]
+    },
+    {
+      "comment": "Bash sigil with pipes",
+      "begin": "~b\\|",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\|[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "source.shell"
+        }
+      ]
+    },
+    {
+      "comment": "Bash sigil with double quotes",
+      "begin": "~b\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\\"[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "source.shell"
+        }
+      ]
+    },
+    {
+      "comment": "Bash sigil with single quotes",
+      "begin": "~b\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\'[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "source.shell"
+        }
+      ]
+    },
+    {
+      "comment": "Literal Bash sigil with double quoted heredoc",
+      "begin": "\\s?(~BASH\"\"\")$",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "end": "^\\s*(\"\"\"[SEOsvpu]*)$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "source.shell"
+        }
+      ]
+    },
+    {
+      "comment": "Literal Bash sigil with single quoted heredoc",
+      "begin": "\\s?(~BASH''')$",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "end": "^\\s*('''[SEOsvpu]*)$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "source.shell"
+        }
+      ]
+    },
+    {
+      "comment": "Literal Bash sigil with curlies",
+      "begin": "~BASH\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\}[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "source.shell"
+        },
+        {
+          "include": "#nest_curly"
+        }
+      ]
+    },
+    {
+      "comment": "Literal Bash sigil with brackets",
+      "begin": "~BASH\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\][SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "source.shell"
+        },
+        {
+          "include": "#nest_brackets"
+        }
+      ]
+    },
+    {
+      "comment": "Literal Bash sigil with angle brackets",
+      "begin": "~BASH\\<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\>[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "source.shell"
+        },
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "comment": "Literal Bash sigil with parens",
+      "begin": "~BASH\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\)[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "source.shell"
+        },
+        {
+          "include": "#nest_parens"
+        }
+      ]
+    },
+    {
+      "comment": "Literal Bash sigil with slashes",
+      "begin": "~BASH\\/",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\/[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "source.shell"
+        }
+      ]
+    },
+    {
+      "comment": "Literal Bash sigil with pipes",
+      "begin": "~BASH\\|",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\|[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "source.shell"
+        }
+      ]
+    },
+    {
+      "comment": "Literal Bash sigil with double quotes",
+      "begin": "~BASH\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\\"[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "source.shell"
+        }
+      ]
+    },
+    {
+      "comment": "Literal Bash sigil with single quotes",
+      "begin": "~BASH\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\'[SEOsvpu]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "source.shell",
+      "patterns": [
+        {
+          "include": "source.shell"
+        }
+      ]
+    },
+    {
       "begin": "~[a-z](?>\"\"\")",
       "beginCaptures": {
         "0": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": ["ES2020"],
     "outDir": "out",
     "sourceMap": true,
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   },
   "exclude": ["node_modules", ".vscode-test", "elixir-ls", "elixir-ls-release"]
 }


### PR DESCRIPTION
This adds `~b` and `~BASH` syntax highlighting provided by the https://hexdocs.pm/bash package.  There wasn't a great way to test this, so I had to get VSCode's way of testing grammars setup as well, which is most of the change here.

VSCode ships with `shellscript` grammar, so this shouldn't require any external dependencies.

Most of the lines in `elixir.json` are repeated to support all the different fences around sigils, just like regex, but they're all the same.

I'm not a VSCode users, so feel free to give it a thorough review.

<img width="409" height="270" alt="Screenshot 2026-03-12 at 3 27 36 PM" src="https://github.com/user-attachments/assets/006aee42-745d-426b-8039-f56f8d1dcd11" />